### PR TITLE
Fix assertion error with example make scripts

### DIFF
--- a/examples/make_mf2000.py
+++ b/examples/make_mf2000.py
@@ -64,14 +64,15 @@ def make_mf2000():
                 expedite=False, dryrun=False, double=False, debug=False)
 
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
 

--- a/examples/make_mf2000.py
+++ b/examples/make_mf2000.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -62,6 +63,16 @@ def make_mf2000():
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False)
 
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # Remove MODFLOW-2000 files

--- a/examples/make_mf2005.py
+++ b/examples/make_mf2005.py
@@ -35,14 +35,15 @@ def make_mf2005():
                 expedite=False, dryrun=False, double=True, debug=False)
     
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
 

--- a/examples/make_mf2005.py
+++ b/examples/make_mf2005.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip

--- a/examples/make_mf2005.py
+++ b/examples/make_mf2005.py
@@ -32,7 +32,17 @@ def make_mf2005():
     target = 'mf2005dbl'
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=True, debug=False)
-
+    
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # Clean up downloaded directory

--- a/examples/make_mflgr.py
+++ b/examples/make_mflgr.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -26,10 +27,18 @@ def make_mflgr():
     #            expedite=False, dryrun=False, double=True, debug=False)
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=True, debug=False)
-
-
+    
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+    
     assert os.path.isfile(target), 'Target does not exist.'
-
 
 if __name__ == "__main__":
     make_mflgr()

--- a/examples/make_mflgr.py
+++ b/examples/make_mflgr.py
@@ -29,15 +29,16 @@ def make_mflgr():
                 expedite=False, dryrun=False, double=True, debug=False)
     
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
-    
+            if not '.' in target:
+                target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
 if __name__ == "__main__":

--- a/examples/make_mfnwt.py
+++ b/examples/make_mfnwt.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -27,9 +28,19 @@ def make_mfnwt():
 
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False)
-
+    
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
-
+    
     # Clean up
     if os.path.isdir(dirname):
         shutil.rmtree(dirname)

--- a/examples/make_mfnwt.py
+++ b/examples/make_mfnwt.py
@@ -30,14 +30,15 @@ def make_mfnwt():
                 expedite=False, dryrun=False, double=False, debug=False)
     
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
     

--- a/examples/make_mfusg.py
+++ b/examples/make_mfusg.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -36,6 +37,16 @@ def make_mfusg():
 
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False)
+    
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
 
     assert os.path.isfile(target), 'Target does not exist.'
 

--- a/examples/make_mfusg.py
+++ b/examples/make_mfusg.py
@@ -39,15 +39,16 @@ def make_mfusg():
                 expedite=False, dryrun=False, double=False, debug=False)
     
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
-
+            if not '.' in target:
+                target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # Remove the existing mfusg.1_3 directory if it exists

--- a/examples/make_modflow6.py
+++ b/examples/make_modflow6.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -30,6 +31,16 @@ def make_mf6():
                 expedite=False, dryrun=False, double=False, debug=False,
                 include_subdirs=True)
 
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # Remove the existing mf6.0.1 directory if it exists

--- a/examples/make_modflow6.py
+++ b/examples/make_modflow6.py
@@ -32,14 +32,15 @@ def make_mf6():
                 include_subdirs=True)
 
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
 

--- a/examples/make_modpath6.py
+++ b/examples/make_modpath6.py
@@ -68,14 +68,15 @@ def make_modpath6():
                 expedite=False, dryrun=False, double=False, debug=False)
 
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
 

--- a/examples/make_modpath6.py
+++ b/examples/make_modpath6.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -66,6 +67,16 @@ def make_modpath6():
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False)
 
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # if os.path.isdir(dirname):

--- a/examples/make_modpath7.py
+++ b/examples/make_modpath7.py
@@ -78,14 +78,15 @@ def make_modpath7():
                 fflags=fflags)
 
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
 

--- a/examples/make_modpath7.py
+++ b/examples/make_modpath7.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -76,6 +77,16 @@ def make_modpath7():
                 expedite=False, dryrun=False, double=False, debug=False,
                 fflags=fflags)
 
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # change back to the original path

--- a/examples/make_mt3dusgs.py
+++ b/examples/make_mt3dusgs.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -40,6 +41,16 @@ def make_mt3dusgs():
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False)
 
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # Remove the existing MT3D-USGS directory if it exists

--- a/examples/make_mt3dusgs.py
+++ b/examples/make_mt3dusgs.py
@@ -42,14 +42,15 @@ def make_mt3dusgs():
                 expedite=False, dryrun=False, double=False, debug=False)
 
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
 

--- a/examples/make_swtv4.py
+++ b/examples/make_swtv4.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import os
+import sys
 import shutil
 import pymake
 from pymake.download import download_and_unzip
@@ -63,6 +64,16 @@ def make_swtv4():
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=True, debug=False)
 
+    if sys.platform == 'win32':
+        # Based on ifort 12 compilation, 'exe' is appended on the target
+        # This necessitates assert expression with different target name
+        try:
+            # Additional check in case the target does not have 'exe'
+            # extension with different compiler 
+            assert os.path.isfile(target), 'Target does not exist.'
+        except:
+            target = target + '.exe'
+            
     assert os.path.isfile(target), 'Target does not exist.'
 
     # Remove the existing directory if it exists

--- a/examples/make_swtv4.py
+++ b/examples/make_swtv4.py
@@ -65,14 +65,15 @@ def make_swtv4():
                 expedite=False, dryrun=False, double=True, debug=False)
 
     if sys.platform == 'win32':
-        # Based on ifort 12 compilation, 'exe' is appended on the target
-        # This necessitates assert expression with different target name
+        # 'exe' is appended to the target name upon compilation
+        # 'exe' is not appended if target already has extension part
         try:
             # Additional check in case the target does not have 'exe'
             # extension with different compiler 
             assert os.path.isfile(target), 'Target does not exist.'
         except:
-            target = target + '.exe'
+            if not '.' in target:
+                target = target + '.exe'
             
     assert os.path.isfile(target), 'Target does not exist.'
 


### PR DESCRIPTION
On Windows, the compiled executable contains 'exe' extension (tested with ifort 12 and gfortran) when the provided target name does not have extension part. Because of this, assertion error of type Target Does Not Exist occurs at the end of various make scripts in spite of successful compilation. 