### PR TITLE
Updates make_modpath7.py to improve consistency

### DIFF
--- a/examples/make_modpath7.py
+++ b/examples/make_modpath7.py
@@ -41,7 +41,7 @@ def make_modpath7():
     f2.close()
     os.remove(fname1)
     os.rename(fname2, fname1)
-    
+
     fname1 = os.path.join(srcdir, 'ModpathCellData.f90')
     f = open(fname1, 'r')
     fname2 = os.path.join(srcdir, 'ModpathCellData_mod.f90')
@@ -54,7 +54,7 @@ def make_modpath7():
     f2.close()
     os.remove(fname1)
     os.rename(fname2, fname1)
-    
+
     fname1 = os.path.join(srcdir, 'MPath7.f90')
     f = open(fname1, 'r')
     fname2 = os.path.join(srcdir, 'MPath7_mod.f90')
@@ -71,7 +71,7 @@ def make_modpath7():
     fflags='ffree-line-length-512'
 
     # make modpath 7 in starting directory
-    target = os.path.join('..', 'mp7')
+    target = os.path.join('.', 'mp7')
     pymake.main(srcdir, target, 'gfortran', 'gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False,
                 fflags=fflags)
@@ -82,8 +82,8 @@ def make_modpath7():
     os.chdir(srcpth)
 
     # remove temporary directory
-    if os.path.isdir(dstpth):
-        shutil.rmtree(dstpth)
+    if os.path.isdir(dwpath):
+        shutil.rmtree(dwpath)
 
 if __name__ == "__main__":
     make_modpath7()


### PR DESCRIPTION
This example-file compiles modpath7 correctly but leaves the binary file in the root-folder and deletes the temp folder.
In all other examples, the binary file of the compiled source code is created and left in the temp-folder.
So I'll propose, improving consistency, to do the same here.
My changes are:
* setting the target to ./temp/mf7
* remove ./temp/Modpath_7_1_000 after finishing the compilation
* do not delete the temp-folder

After this, with this oneliner all binaries can be compiled at once:

```
 for file in ./examples/*; do python3 $file 2>/dev/null; done
```