### PR TITLE
Remove extra interpretations to fflags

### DIFF
--- a/autotest/t001_test.py
+++ b/autotest/t001_test.py
@@ -83,7 +83,7 @@ def test_compile_prev():
     # compile
     pymake.main(srcdir, target, fc='gfortran', cc='gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False,
-                include_subdirs=False, fflags='O3')
+                include_subdirs=False, fflags='-O3')
 
     assert os.path.isfile(target), 'Target {} does not exist.'.format(target)
 
@@ -110,7 +110,7 @@ def test_compile_ref():
     # compile
     pymake.main(srcdir, target, fc='gfortran', cc='gcc', makeclean=True,
                 expedite=False, dryrun=False, double=False, debug=False,
-                include_subdirs=False, fflags='O3 fbacktrace')
+                include_subdirs=False, fflags='-O3 -fbacktrace')
 
     assert os.path.isfile(target), 'Target {} does not exist.'.format(target)
 

--- a/autotest/t007_test.py
+++ b/autotest/t007_test.py
@@ -57,7 +57,7 @@ def compile_code(pth=None, url=None, srcdir=None, exe=None):
         update_files(src)
 
     # allow line lengths greater than 132 columns
-    fflags = 'ffree-line-length-512'
+    fflags = '-ffree-line-length-512'
 
     # make binary file
     pymake.main(src, binpth, 'gfortran', 'gcc', makeclean=True,


### PR DESCRIPTION
Flags should be passed as expected by the compiler. Currently, pymake's checking/adding '-' to each fflag token is problematic for (e.g.) Intel, which can have flags with spaces like `-warn unused`. Also, compiler flags are always case-sensitive, so there's no need to do `.upper()` on these. (Also, these spaces need to be split in cmdlist to work correctly with Popen, which is done here too.)

This is a minor breaking change, in that external tools that use pymake will need to ensure the fflags have dashes, where they would normally be expected by the compiler.

There are many other changes included here (got carried away):
 * `fflags` can either be a str `'-flag1 -flag two'` or list `['-flag1', '-flag two']`
 * Correct ifort `-double_size` to `-double-size`, and `/real_size` to `/real-size`
 * Use more descriptive `-real-size 64` instead of `-r8` (does same thing)
 * Decode messages for Python 3
 * Simplify `flag_available()`; document some limitations in docstring
 * Use Windows flags as documented (usually `/flag:1` rather than `-flag 1`)
