### PR TITLE
Modification to facilitate testing of MF6/MT3D-USGS linkage

### DIFF
--- a/pymake/autotest.py
+++ b/pymake/autotest.py
@@ -296,7 +296,7 @@ def get_sim_name(namefiles, rootpth=None):
 
 
 # modflow 6 readers and copiers
-def setup_mf6(src, dst, mfnamefile='mfsim.nam', extrafiles=None):
+def setup_mf6(src, dst, mfnamefile='mfsim.nam', extrafiles=None, remove_existing=True):
     """
 
     Copy all of the MODFLOW 6 input files from the src directory to
@@ -316,10 +316,16 @@ def setup_mf6(src, dst, mfnamefile='mfsim.nam', extrafiles=None):
     import shutil
 
     # Create the destination folder
+    create_dir = False
     if os.path.exists(dst):
-        print('Removing folder ' + dst)
-        shutil.rmtree(dst)
-    os.mkdir(dst)
+        if remove_existing:
+            print('Removing folder ' + dst)
+            shutil.rmtree(dst)
+            create_dir = True
+    else:
+        create_dir = True
+    if create_dir:
+        os.mkdir(dst)
 
     # Make list of files to copy
     fname = os.path.join(src, mfnamefile)

--- a/pymake/autotest.py
+++ b/pymake/autotest.py
@@ -8,7 +8,7 @@ ignore_ext = ['.hds', '.hed', '.bud', '.cbb', '.cbc',
               '.gwv', '.mv', '.out']
 
 
-def setup(namefile, dst, remove_existing=True):
+def setup(namefile, dst, remove_existing=True, extrafiles=None):
     # Construct src pth from namefile or lgr file
     src = os.path.dirname(namefile)
 
@@ -50,6 +50,12 @@ def setup(namefile, dst, remove_existing=True):
         if ext.lower() == '.nam':
             fname = os.path.abspath(fpth)
             files2copy = files2copy + get_input_files(fname)
+
+    if extrafiles is not None:
+        if isinstance(extrafiles, str):
+            extrafiles = [extrafiles]
+        for fl in extrafiles:
+            files2copy.append(os.path.basename(fl))
 
     # Copy the files
     for f in files2copy:


### PR DESCRIPTION
To make regressions tests of MF**5**/MT3D-USGS and MF**6**/MT3D-USGS easier it is handy to pull MF6 simulation files into the directory where MF5 (i.e., all MF variants prior to MF6) input is hanging out without those files being deleted.  