### PR TITLE
only set download directory to 'temp' if it is None

### DIFF
--- a/pymake/pymake_build_apps.py
+++ b/pymake/pymake_build_apps.py
@@ -156,7 +156,8 @@ def build_apps(
             update_target_name = True
 
         # set download information
-        download_dir = "temp"
+        if download_dir is None:
+            download_dir = "temp"
         download_verify = True
         timeout = 30
 


### PR DESCRIPTION
Regardless of the `download_directory` given by the user it is always set to `'temp'`. With the proposed changes the `download_directory` is only set to `'temp'` if not defined by user (`None`).