### PR TITLE
fix(numpy): aliases of builtin types is deprecated as of numpy 1.20

### DIFF
--- a/pymake/autotest/autotest.py
+++ b/pymake/autotest/autotest.py
@@ -1118,9 +1118,9 @@ def compare_budget(
     lst2.append(lst2obj.get_cumulative())
 
     icnt = 0
-    v0 = np.zeros(2, dtype=np.float)
-    v1 = np.zeros(2, dtype=np.float)
-    err = np.zeros(2, dtype=np.float)
+    v0 = np.zeros(2, dtype=float)
+    v1 = np.zeros(2, dtype=float)
+    err = np.zeros(2, dtype=float)
 
     # Process cumulative and incremental
     for idx in range(2):
@@ -1312,9 +1312,9 @@ def compare_swrbudget(
     lst2.append(lst2obj.get_cumulative())
 
     icnt = 0
-    v0 = np.zeros(2, dtype=np.float)
-    v1 = np.zeros(2, dtype=np.float)
-    err = np.zeros(2, dtype=np.float)
+    v0 = np.zeros(2, dtype=float)
+    v1 = np.zeros(2, dtype=float)
+    err = np.zeros(2, dtype=float)
 
     # Open output file
     if outfile is not None:


### PR DESCRIPTION
These changes shouldn't change anything, since types like `np.float` are alias to builtin `float` types. These alias are deprecated as of [numpy 1.20](https://numpy.org/doc/stable/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).