### PR TITLE
fix(setup.cfg): use 'find:' to include submodules; other tidying

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,5 +1,11 @@
 # pymake Installation
 
+To install a stable version from PyPI:
+
+```
+pip install mfpymake
+```
+
 To install pymake directly from the git repository type:
 
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,11 @@ version = attr: pymake.config.__version__
 description = pymake is a Python package to compile MODFLOW-based models.
 long_description = file: README.md
 long_description_content_type = text/markdown
-author = attr: Joseph D. Hughes
+author = Joseph D. Hughes
 author_email = modflow@usgs.gov
-maintainer = attr: Joseph D. Hughes
+maintainer = Joseph D. Hughes
 maintainer_email = jdhughes@usgs.gov
 license = CC0
-license_files = LICENSE, LICENSE.md
 platform = Windows, Mac OS-X, Linux
 keywords = MODFLOW, groundwater, hydrogeology
 classifiers =
@@ -29,15 +28,13 @@ project_urls =
 [options]
 include_package_data = True  # includes files listed in MANIFEST.in
 zip_safe = False
-packages = pymake
+packages = find:
 python_requires = >=3.7
 install_requires =
     numpy >= 1.15.0
     requests
     networkx
 
-[sdist]
-formats = zip
 
 [flake8]
 exclude =


### PR DESCRIPTION
This should fix the missing modules using the special `find:` directive [described here](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html). Also remove `attr:`, which only works for `version`, and remove sdist option, as it's probably not used here. I don't see the licence files, but this shouldn't matter.

The best way to build/check the package is using `python -m build` (which may required `python -m pip install build`, if not already there. And better from PyPI than conda for this tool, as it's written by PyPI).

Also update the installation documentation for presumably the stable version from PyPI.