### PR TITLE
fix(package build): include pyproject.toml for sdist, add check

### DIFF
--- a/.github/workflows/pymake-linting-install.yml
+++ b/.github/workflows/pymake-linting-install.yml
@@ -77,10 +77,10 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Upgrade pip and install wheel
+      - name: Upgrade pip and install build and twine
         run: |
           python -m pip install --upgrade pip
-          pip install wheel
+          pip install build twine
 
       - name: Base pymake installation
         run: |
@@ -89,4 +89,9 @@ jobs:
       - name: Print pymake version
         run: |
           python -c "import pymake; print(pymake.__version__)"
+
+      - name: Build pymake, check dist outputs
+        run: |
+          python -m build
+          twine check --strict dist/*
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 global-exclude .DS_Store *.pyc *.pyo *.pyd *.swp *.bak *~ .* *.sh *.yml *.md *.toml
 exclude docs/*
 exclude autotest/*
+include pyproject.toml
 include pymake/utils/usgsprograms.txt
 include examples/*.bat
 include examples/*.py

--- a/pymake/autotest/autotest.py
+++ b/pymake/autotest/autotest.py
@@ -51,6 +51,8 @@ import os
 import shutil
 import textwrap
 
+import numpy as np
+
 ignore_ext = (
     ".hds",
     ".hed",
@@ -1047,8 +1049,6 @@ def compare_budget(
         than max_cumpd and max_incpd
 
     """
-    import numpy as np
-
     try:
         import flopy
     except:
@@ -1255,8 +1255,6 @@ def compare_swrbudget(
         than max_cumpd and max_incpd
 
     """
-    import numpy as np
-
     try:
         import flopy
     except:
@@ -1477,8 +1475,6 @@ def compare_heads(
         boolean indicating if the head differences are less than htol.
 
     """
-    import numpy as np
-
     try:
         import flopy
     except:
@@ -1875,8 +1871,6 @@ def compare_concs(
     -------
 
     """
-    import numpy as np
-
     try:
         import flopy
     except:
@@ -2287,8 +2281,6 @@ def _calculate_diffmax(v1, v2):
         absolute value of the maximum difference.
 
     """
-    import numpy as np
-
     if v1.ndim > 1 or v2.ndim > 1:
         v1 = v1.flatten()
         v2 = v2.flatten()
@@ -2325,8 +2317,6 @@ def _calculate_difftol(v1, v2, tol):
         specified tolerance.
 
     """
-    import numpy as np
-
     if v1.ndim > 1 or v2.ndim > 1:
         v1 = v1.flatten()
         v2 = v2.flatten()


### PR DESCRIPTION
Closes #111

The issue is that the source distribution did not include the build dependencies from `pyproject.toml`.

This PR does a partial rollback of c370efa28866ce7391a7e8f1d9a14edba6682eec and does two extra checks: [build](https://github.com/pypa/build) (which would have failed before), and checks the source distribution and wheels using [twine](https://github.com/pypa/twine).

Note that two files should normally be uploaded to PyPI: a sdist (.tar.gz) and wheels (.whl). This can be done with twine.