### PR TITLE
Use basename only when checking for gfortran

### DIFF
--- a/pymake/pymake_base.py
+++ b/pymake/pymake_base.py
@@ -962,7 +962,7 @@ def _pymake_compile(
                     cmdlist.append(switch)
                 # add preprocessor option, if necessary
                 if _preprocess_file(srcfile):
-                    if fc == "gfortran":
+                    if os.path.basename(fc) == "gfortran":
                         pp_tag = "-cpp"
                     else:
                         pp_tag = "-fpp"


### PR DESCRIPTION
In attempting to build on our system, we identified fc here as containing the entire path to gfortran, which caused the preprocessor directive to be set erroneously as `-fpp` instead of `cpp` . Using the basename solved the issue in our case and would be expected to deliver the correct behavior generally.