### PR TITLE
refactor: test for intel oneapi env vars

### DIFF
--- a/pymake/pymake_base.py
+++ b/pymake/pymake_base.py
@@ -1165,9 +1165,11 @@ def _create_win_batch(
     # open the batch file
     f = open(batchfile, "w")
 
-    # write the compilervars batch command to batchfile
-    line = "call " + intel_setvars + "\n"
-    f.write(line)
+    # only write the compilervars batch command to batchfile if env vars aren't already configured
+    # https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html
+    if os.environ.get("SETVARS_COMPLETED") != "1":
+        line = "call " + intel_setvars + "\n"
+        f.write(line)
 
     # assume that header files may be in other folders, so make a list
     searchdir = []


### PR DESCRIPTION
This PR checks for the `SETVARS_COMPLETED` environment variable before running Intel oneAPI `setvars` scripts. This variable is [set to `1` by Intel oneAPI scripts](https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html) to indicate that the oneAPI environment has been configured. This can prevent [path length errors on Windows](https://github.com/w-bonelli/install-intelfortran-action/actions/runs/3643834756/jobs/6152439435#step:11:3793) caused by repeatedly running `setvars` scripts in the same session.