### PR TITLE
fix(cli): fix make-program to take ':' target value

### DIFF
--- a/.github/common/install-python.sh
+++ b/.github/common/install-python.sh
@@ -2,7 +2,7 @@
 
 python -m pip install --upgrade pip
 pip install wheel
-pip install pytest pytest-cov pytest-xdist pytest-dependency coverage
+pip install pytest pytest-cov pytest-xdist pytest-dependency flaky coverage
 pip install appdirs matplotlib
 pip install https://github.com/modflowpy/flopy/zipball/develop
 pip install .

--- a/.github/workflows/pymake-requests.yml
+++ b/.github/workflows/pymake-requests.yml
@@ -34,6 +34,11 @@ jobs:
         run: |
           pytest -v -m requests --durations=0 --cov=pymake --cov-report=xml autotest/
 
+      - name: Run scheduled tests
+        if: ${{ github.event_name == 'schedule' }}
+        run: |
+          pytest -v -m="schedule" --durations=0 --cov=pymake --cov-report=xml autotest/
+
       - name: Print coverage report before upload
         run: |
           coverage report

--- a/autotest/test_cli_cmds.py
+++ b/autotest/test_cli_cmds.py
@@ -60,6 +60,20 @@ def test_make_program(target: str) -> None:
     run_cli_cmd(cmd)
 
 
+@pytest.mark.dependency(name="make_program_all")
+@pytest.mark.schedule
+def test_make_program_all() -> None:
+    cmd = [
+        "make-program",
+        ":",
+        "--appdir",
+        str(dstpth / "all"),
+        "--verbose",
+        "--dryrun",
+    ]
+    run_cli_cmd(cmd)
+
+
 @pytest.mark.dependency(name="mfpymake")
 @pytest.mark.base
 def test_mfpymake() -> None:

--- a/autotest/test_requests.py
+++ b/autotest/test_requests.py
@@ -6,9 +6,11 @@ import subprocess
 import sys
 
 import pytest
+from flaky import flaky
 
 import pymake
 
+RERUNS = 3
 dstpth = os.path.join(f"temp_{os.path.basename(__file__).replace('.py', '')}")
 
 
@@ -80,6 +82,7 @@ def run_cli_cmd(cmd: list) -> None:
 
 
 @pytest.mark.dependency("latest_version")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_latest_version():
     version = pymake.repo_latest_version()
@@ -96,6 +99,7 @@ def test_latest_version():
 
 
 @pytest.mark.dependency("latest_assets")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_latest_assets():
     mfexes_repo_name = "MODFLOW-USGS/executables"
@@ -116,6 +120,7 @@ def test_latest_assets():
 
 
 @pytest.mark.dependency("previous_assets")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_previous_assets():
     # hack for failure of OSX on github actions
@@ -147,6 +152,7 @@ def test_previous_assets():
 
 
 @pytest.mark.dependency("mfexes")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_mfexes_download_and_unzip_and_zip():
     exclude_files = [
@@ -228,6 +234,7 @@ def test_mfexes_download_and_unzip_and_zip():
 
 
 @pytest.mark.dependency("nightly_download")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_nightly_download_and_unzip():
     exclude_files = ["code.json"]
@@ -249,6 +256,7 @@ def test_nightly_download_and_unzip():
 
 
 @pytest.mark.dependency("usgsprograms")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_usgsprograms():
     print("test_usgsprograms()")
@@ -263,6 +271,7 @@ def test_usgsprograms():
 
 
 @pytest.mark.dependency("target_key_error")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_target_key_error():
     print("test_target_key_error()")
@@ -271,6 +280,7 @@ def test_target_key_error():
 
 
 @pytest.mark.dependency("target_keys")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_target_keys():
     print("test_target_keys()")
@@ -288,6 +298,7 @@ def test_target_keys():
 
 
 @pytest.mark.dependency("export_json")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_usgsprograms_export_json():
     # export code.json and return json file path
@@ -318,6 +329,7 @@ def test_usgsprograms_export_json():
 
 
 @pytest.mark.dependency("load_json_error")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_usgsprograms_load_json_error():
     print("test_usgsprograms_load_json_error()")
@@ -335,6 +347,7 @@ def test_usgsprograms_load_json_error():
 
 
 @pytest.mark.dependency("load_json")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_usgsprograms_load_json():
     print("test_usgsprograms_load_json()")
@@ -350,6 +363,7 @@ def test_usgsprograms_load_json():
 
 
 @pytest.mark.dependency("list_json_error")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_usgsprograms_list_json_error():
     print("test_usgsprograms_list_json_error()")
@@ -363,6 +377,7 @@ def test_usgsprograms_list_json_error():
 
 
 @pytest.mark.dependency("list_json")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_usgsprograms_list_json():
     print("test_usgsprograms_list_json()")
@@ -375,6 +390,7 @@ def test_usgsprograms_list_json():
 
 
 @pytest.mark.dependency("shared")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_shared():
     print("test_shared()")
@@ -383,6 +399,7 @@ def test_shared():
 
 
 @pytest.mark.dependency("not_shared")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_not_shared():
     print("test_not_shared()")
@@ -391,6 +408,7 @@ def test_not_shared():
 
 
 @pytest.mark.dependency(name="code_json")
+@flaky(max_runs=RERUNS)
 @pytest.mark.requests
 def test_code_json() -> None:
     cmd = ["make-code-json", "-f", f"{dstpth}/code.json"]

--- a/pymake/pymake.py
+++ b/pymake/pymake.py
@@ -125,7 +125,10 @@ class Pymake:
             setattr(self, key, value["default"])
 
         # parse command line arguments if python is running script
-        if sys.argv[0].lower().endswith(".py"):
+        if (
+            sys.argv[0].lower().endswith(".py")
+            or "make-program" in sys.argv[0].lower()
+        ):
             self._arg_parser()
 
         # reset select variables using passed variables

--- a/pymake/pymake_build_apps.py
+++ b/pymake/pymake_build_apps.py
@@ -80,6 +80,13 @@ def build_apps(
     """
 
     start_time = datetime.now()
+
+    # intercept all string (":") from make-program
+    if isinstance(targets, str):
+        if targets == ":":
+            targets = None
+
+    # set targets
     if targets is None:
         targets = usgs_program_data.get_keys(current=True)
     else:


### PR DESCRIPTION
Fix parsing command-line arguments when using make-program. 
Add test for ':' make-program target value.