### PR TITLE
refactor(ci/tests): use awvwgk/setup-fortran, use pytest tempdirs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 7 * * *' # run at 7 AM UTC every day
   push:
-    branches: [ master ]
+    branches: 
+      - master
   pull_request:
     branches:
       - master
@@ -25,8 +26,18 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Setup Intel OneAPI Compilers
-        uses: modflowpy/install-intelfortran-action@v1
+      - name: Setup Intel Fortran Classic
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: intel-classic
+          version: 2021.7.0
+      
+      - name: Set SETVARS_COMPLETED (temporary)
+        run: echo "SETVARS_COMPLETED=1" >> $GITHUB_ENV
+
+      - name: Set CXX (temporary)
+        if: runner.os == 'Windows'
+        run: echo "CXX=icl" >> $GITHUB_ENV
 
       - name: Setup Graphviz
         if: runner.os == 'Linux'
@@ -63,7 +74,7 @@ jobs:
         working-directory: ./autotest
         shell: cmd
         run: |
-          pytest -v -m="base" --durations=0 --cov=pymake --cov-report=xml
+          pytest -v -m="base" --durations=0 --cov=pymake --cov-report=xml --basetemp=pytest_temp
 
       - name: Print coverage report before upload
         working-directory: ./autotest

--- a/.github/workflows/pymake-gcc.yml
+++ b/.github/workflows/pymake-gcc.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 7 * * *' # run at 7 AM UTC every day
   push:
-    branches: [ master ]
+    branches: 
+      - master
   pull_request:
     branches:
       - master
@@ -39,8 +40,11 @@ jobs:
           python -m pip install --upgrade pip
           pip install ".[test]"
 
-      - name: Install GNU Fortran
-        uses: modflowpy/install-gfortran-action@v1
+      - name: Setup GNU Fortran
+        uses: awvwgk/setup-fortran@main
+        with:
+          compiler: gcc
+          version: 11
 
       - name: Download examples for pytest runs
         run: |
@@ -49,7 +53,7 @@ jobs:
       - name: Run pytest
         working-directory: ./autotest
         run: |
-          pytest -v --dist=loadfile -n=auto -m="base or regression" --durations=0 --cov=pymake --cov-report=xml
+          pytest -v --dist=loadfile -n=auto -m="base or regression" --durations=0 --cov=pymake --cov-report=xml --basetemp=pytest_temp
 
       - name: Print coverage report before upload
         working-directory: ./autotest

--- a/.github/workflows/pymake-linting-install.yml
+++ b/.github/workflows/pymake-linting-install.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 3 * * 3' # run at 3 AM UTC every Wednesday
   push:
-    branches: [ master ]
+    branches: 
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/pymake-requests.yml
+++ b/.github/workflows/pymake-requests.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 7 * * *' # run at 7 AM UTC every day
   push:
-    branches: [ master ]
+    branches: 
+      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/pymake-rtd.yml
+++ b/.github/workflows/pymake-rtd.yml
@@ -4,7 +4,8 @@ on:
   schedule:
     - cron: '0 3 * * 3' # run at 3 AM UTC every Wednesday
   push:
-    branches: [ master ]
+    branches: 
+      - master
   pull_request:
     branches:
       - master

--- a/autotest/pytest.ini
+++ b/autotest/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 markers =
     base: base tests
+    dependency: tests that depend on other tests (via pytest-dependency)
     regression: regression tests
     requests: usgsprograms requests tests
     schedule: tests to run if a scheduled job

--- a/autotest/test_mflgr.py
+++ b/autotest/test_mflgr.py
@@ -1,74 +1,34 @@
-import os
-import shutil
+from pathlib import Path
 
 import pytest
 
 import pymake
 
-# define program data
-target = "mflgr"
 
-# get program dictionary
-prog_dict = pymake.usgs_program_data.get_target(target)
-
-# set up paths
-dstpth = os.path.join(f"temp_{os.path.basename(__file__).replace('.py', '')}")
-if not os.path.exists(dstpth):
-    os.makedirs(dstpth, exist_ok=True)
-
-mflgrpth = os.path.join(dstpth, prog_dict.dirname)
+@pytest.fixture(scope="module")
+def target(module_tmpdir) -> Path:
+    target = "mflgr"
+    return module_tmpdir / target
 
 
-def compile_code():
-    # Remove the existing mfusg directory if it exists
-    if os.path.isdir(mflgrpth):
-        shutil.rmtree(mflgrpth)
+@pytest.fixture(scope="module")
+def prog_dict(target) -> dict:
+    return pymake.usgs_program_data.get_target(target)
 
-    # compile MODFLOW-LGR
+
+@pytest.fixture(scope="module")
+def workspace(module_tmpdir, prog_dict) -> Path:
+    return module_tmpdir / prog_dict.dirname
+
+
+def compile_code(ws, exe):
     return pymake.build_apps(
-        target, download_dir=dstpth, appdir=dstpth, verbose=True
+        str(exe), download_dir=ws, appdir=ws, verbose=True
     )
 
 
-def clean_up():
-    print("Removing test files and directories")
-
-    # clean up download directory
-    print("Removing folder " + mflgrpth)
-    if os.path.isdir(mflgrpth):
-        shutil.rmtree(mflgrpth)
-
-    # get list of files with target in name
-    epths = []
-    for file in os.listdir(dstpth):
-        fpth = os.path.join(dstpth, file)
-        if os.path.isfile(fpth):
-            if target in file:
-                epths.append(fpth)
-
-    # clean up the executable
-    for epth in epths:
-        print("removing...'" + epth + "'")
-        os.remove(epth)
-
-    dirs_temp = [dstpth]
-    for d in dirs_temp:
-        if os.path.isdir(d):
-            shutil.rmtree(d)
-
-    return
-
-
 @pytest.mark.base
-def test_compile():
-    assert compile_code() == 0, f"could not compile {target}"
-
-
-@pytest.mark.base
-def test_clean_up():
-    clean_up()
-
-
-if __name__ == "__main__":
-    compile_code()
-    clean_up()
+def test_compile(module_tmpdir, target):
+    assert (
+        compile_code(module_tmpdir, target) == 0
+    ), f"could not compile {target}"

--- a/autotest/test_mfnwt.py
+++ b/autotest/test_mfnwt.py
@@ -1,54 +1,47 @@
-import contextlib
 import os
-import shutil
 import sys
 import time
+from pathlib import Path
 
 import pytest
+from modflow_devtools.misc import set_dir
 
 import pymake
 
-# define program data
-target = "mfnwt"
-if sys.platform.lower() == "win32":
-    target += ".exe"
 
-# get program dictionary
-prog_dict = pymake.usgs_program_data.get_target(target)
-
-# set up paths
-dstpth = os.path.join(f"temp_{os.path.basename(__file__).replace('.py', '')}")
-if not os.path.exists(dstpth):
-    os.makedirs(dstpth, exist_ok=True)
-
-mfnwtpth = os.path.join(dstpth, prog_dict.dirname)
-
-srcpth = os.path.join(mfnwtpth, prog_dict.srcdir)
-epth = os.path.join(dstpth, target)
-
-pm = pymake.Pymake(verbose=True)
-pm.target = target
-pm.appdir = dstpth
-pm.makefile = True
-pm.makefiledir = dstpth
-pm.inplace = True
-pm.dryrun = False
+@pytest.fixture(scope="module")
+def target(module_tmpdir) -> str:
+    target = "mfnwt"
+    return module_tmpdir / target
 
 
-@contextlib.contextmanager
-def working_directory(path):
-    """Changes working directory and returns to previous on exit."""
-    prev_cwd = os.getcwd()
-    os.chdir(path)
-    try:
-        yield
-    finally:
-        os.chdir(prev_cwd)
+@pytest.fixture(scope="module")
+def prog_data(target) -> dict:
+    return pymake.usgs_program_data.get_target(target.name)
 
 
-def build_with_makefile():
+@pytest.fixture(scope="module")
+def workspace(module_tmpdir, prog_data) -> Path:
+    return module_tmpdir / prog_data.dirname
+
+
+@pytest.fixture(scope="module")
+def pm(module_tmpdir, target) -> pymake.Pymake:
+    pm = pymake.Pymake(verbose=True)
+    pm.target = str(target)
+    pm.appdir = str(module_tmpdir)
+    pm.makefile = True
+    pm.makefiledir = str(module_tmpdir)
+    pm.inplace = True
+    pm.dryrun = False
+    pm.verbose = True
+    yield pm
+    pm.finalize()
+
+
+def build_with_makefile(ws):
     success = True
-    with working_directory(dstpth):
+    with set_dir(ws):
         if os.path.isfile("makefile"):
             # wait to delete on windows
             if sys.platform.lower() == "win32":
@@ -78,67 +71,21 @@ def build_with_makefile():
 
     assert success, errmsg
 
-    return
 
-
-def clean_up():
-    print("Removing test files and directories")
-
-    # clean up make file
-    print("Removing makefile")
-    files = [
-        os.path.join(dstpth, file_name)
-        for file_name in ("makefile", "makedefaults")
-    ]
-    for fpth in files:
-        if os.path.isfile(fpth):
-            os.remove(fpth)
-
-    # finalize pymake object
-    pm.finalize()
-
-    # clean up MODFLOW-NWT
-    if os.path.isfile(epth):
-        print("Removing " + target)
-        os.remove(epth)
-
-    print("Removing temporary build directories")
-    dirs_temp = [dstpth]
-    for d in dirs_temp:
-        if os.path.isdir(d):
-            shutil.rmtree(d)
-
-    return
-
-
+@pytest.mark.dependency(name="download")
 @pytest.mark.base
-def test_download():
-    # Remove the existing mf2005 directory if it exists
-    if os.path.isdir(mfnwtpth):
-        shutil.rmtree(mfnwtpth)
-
-    # download the modflow 2005 release
-    pm.download_target(target, download_path=dstpth)
+def test_download(pm, module_tmpdir, target):
+    pm.download_target(target, download_path=module_tmpdir)
     assert pm.download, f"could not download {target} distribution"
 
 
+@pytest.mark.dependency(name="build", depends=["download"])
 @pytest.mark.base
-def test_compile():
+def test_compile(pm, target):
     assert pm.build() == 0, f"could not compile {target}"
 
 
+@pytest.mark.dependency(name="makefile", depends=["build"])
 @pytest.mark.base
-def test_makefile():
-    build_with_makefile()
-
-
-@pytest.mark.base
-def test_clean_up():
-    clean_up()
-
-
-if __name__ == "__main__":
-    test_download()
-    test_compile()
-    build_with_makefile()
-    clean_up()
+def test_makefile(workspace):
+    build_with_makefile(workspace)

--- a/autotest/test_mfusg.py
+++ b/autotest/test_mfusg.py
@@ -1,54 +1,45 @@
 import os
-import shutil
-import sys
+from platform import system
+from pathlib import Path
 
 import flopy
 import pytest
 
 import pymake
 
-# define program data
-target = "mfusg"
-target_gsi = "mfusg_gsi"
-if sys.platform.lower() == "win32":
-    target += ".exe"
-    target_gsi += ".exe"
 
-# get program dictionary
-prog_dict = pymake.usgs_program_data.get_target(target)
+@pytest.fixture(scope="module")
+def targets(module_tmpdir):
+    ext = ".exe" if system() == "Windows" else ""
+    return [module_tmpdir / f"{name}{ext}" for name in ["mfusg", "mfusg_gsi"]]
 
-# set up paths
-dstpth = os.path.join(f"temp_{os.path.basename(__file__).replace('.py', '')}")
-if not os.path.exists(dstpth):
-    os.makedirs(dstpth, exist_ok=True)
 
-mfusgpth = os.path.join(dstpth, prog_dict.dirname)
-expth = os.path.join(mfusgpth, "test")
+@pytest.fixture(scope="module")
+def prog_data(targets) -> dict:
+    return pymake.usgs_program_data.get_target(targets[0].name)
 
-srcpth = os.path.join(mfusgpth, prog_dict.srcdir)
-epth = os.path.abspath(os.path.join(dstpth, target))
-epth_gsi = os.path.abspath(os.path.join(dstpth, target_gsi))
 
-name_files = [
-    "01A_nestedgrid_nognc/flow.nam",
-    "01B_nestedgrid_gnc/flow.nam",
-    "03A_conduit_unconfined/ex3A.nam",
-    "03B_conduit_unconfined/ex3B.nam",
-    "03C_conduit_unconfined/ex3C.nam",
-    "03D_conduit_unconfined/ex3D.nam",
-    "03_conduit_confined/ex3.nam",
-]
-# add path to name_files
-for idx, namefile in enumerate(name_files):
-    name_files[idx] = os.path.join(expth, namefile)
+@pytest.fixture(scope="module")
+def workspace(module_tmpdir, prog_data) -> Path:
+    return module_tmpdir / prog_data.dirname
 
-pm = pymake.Pymake(verbose=True)
-pm.target = target
-pm.appdir = dstpth
 
-pm_gsi = pymake.Pymake(verbose=True)
-pm_gsi.target = target_gsi
-pm_gsi.appdir = dstpth
+@pytest.fixture(scope="module")
+def pm(module_tmpdir, targets) -> pymake.Pymake:
+    pm = pymake.Pymake(verbose=True)
+    pm.target = str(targets[0])
+    pm.appdir = str(module_tmpdir)
+    yield pm
+    pm.finalize()
+
+
+@pytest.fixture(scope="module")
+def pm_gsi(module_tmpdir, targets) -> pymake.Pymake:
+    pm_gsi = pymake.Pymake(verbose=True)
+    pm_gsi.target = str(targets[1])
+    pm_gsi.appdir = str(module_tmpdir)
+    yield pm_gsi
+    pm_gsi.finalize()
 
 
 def edit_namefile(namefile):
@@ -68,85 +59,50 @@ def edit_namefile(namefile):
     f.close()
 
 
-def clean_up():
-    print("Removing test files and directories")
-
-    # finalize pymake objects
-    pm.finalize()
-    pm_gsi.finalize()
-
-    if os.path.isfile(epth):
-        print("Removing " + target)
-        os.remove(epth)
-
-    if os.path.isfile(epth_gsi):
-        print("Removing " + target_gsi)
-        os.remove(epth_gsi)
-
-    dirs_temp = [dstpth]
-    for d in dirs_temp:
-        if os.path.isdir(d):
-            shutil.rmtree(d)
-
-    return
-
-
 def run_mfusg(fn, exe):
-    # edit namefile
-    edit_namefile(fn)
-    # run test models
-    print(f"running model...{os.path.basename(fn)}")
-    success, buff = flopy.run_model(
+    success, _ = flopy.run_model(
         exe, os.path.basename(fn), model_ws=os.path.dirname(fn), silent=False
     )
     errmsg = f"could not run {fn} with {exe}"
     assert success, errmsg
 
-    return
 
-
+@pytest.mark.dependency(name="download")
 @pytest.mark.base
-def test_download():
-    # Remove the existing mf2005 directory if it exists
-    if os.path.isdir(mfusgpth):
-        shutil.rmtree(mfusgpth)
+def test_download(pm, pm_gsi, module_tmpdir, targets):
+    pm.download_target(targets[0], download_path=module_tmpdir)
+    assert pm.download, f"could not download {targets[0]}"
 
-    # download the modflow-usg release
-    pm.download_target(target, download_path=dstpth)
-    assert pm.download, f"could not download {target}"
-
-    # download the gsi version of modflow-usg
-    pm_gsi.download_target(target_gsi, download_path=dstpth)
-    assert pm_gsi.download, f"could not download {target_gsi}"
+    pm_gsi.download_target(targets[1], download_path=module_tmpdir)
+    assert pm_gsi.download, f"could not download {targets[1]}"
 
 
+@pytest.mark.dependency(name="build", depends=["download"])
 @pytest.mark.base
-def test_compile():
-    assert pm.build() == 0, f"could not compile {target}"
-    assert pm_gsi.build() == 0, f"could not compile {target_gsi}"
-    return
+def test_compile(pm, pm_gsi, targets):
+    assert pm.build() == 0, f"could not compile {targets[0]}"
+    assert (targets[0]).is_file()
+
+    assert pm_gsi.build() == 0, f"could not compile {targets[1]}"
+    assert targets[1].is_file()
 
 
+@pytest.mark.dependency(name="test", depends=["build"])
 @pytest.mark.regression
-@pytest.mark.parametrize("fn", name_files)
-def test_mfusg(fn):
-    run_mfusg(fn, epth)
-    run_mfusg(fn, epth_gsi)
-
-
-@pytest.mark.base
-def test_clean_up():
-    clean_up()
-
-
-if __name__ == "__main__":
-    test_download()
-
-    test_compile()
-
-    # run models
-    for namefile in name_files:
-        run_mfusg(namefile)
-
-    # clean up
-    test_clean_up()
+@pytest.mark.parametrize(
+    "namefile",
+    [
+        "01A_nestedgrid_nognc/flow.nam",
+        "01B_nestedgrid_gnc/flow.nam",
+        "03A_conduit_unconfined/ex3A.nam",
+        "03B_conduit_unconfined/ex3B.nam",
+        "03C_conduit_unconfined/ex3C.nam",
+        "03D_conduit_unconfined/ex3D.nam",
+        "03_conduit_confined/ex3.nam",
+    ],
+)
+def test_mfusg(workspace, namefile, targets):
+    namefile_path = workspace / "test" / namefile
+    edit_namefile(namefile_path)
+    run_mfusg(namefile_path, targets[0])
+    run_mfusg(namefile_path, targets[1])

--- a/autotest/test_misc_programs.py
+++ b/autotest/test_misc_programs.py
@@ -1,73 +1,24 @@
-import os
-import shutil
-import sys
-
 import pytest
 
 import pymake
 
-# define program data
 targets = [
     "crt",
     "vs2dt",
     "zonbud3",
 ]
 
-app_extension = ""
-if sys.platform.lower() == "win32":
-    app_extension = ".exe"
-
-for idx, target in enumerate(targets):
-    target_dict = pymake.usgs_program_data.get_target(target)
-    extension = app_extension
-    targets[idx] = target + extension
-
-# set up paths
-dstpth = os.path.join(f"temp_{os.path.basename(__file__).replace('.py', '')}")
-if not os.path.exists(dstpth):
-    os.makedirs(dstpth, exist_ok=True)
-
-appdir = os.path.join(dstpth, "bin")
-if not os.path.exists(appdir):
-    os.makedirs(appdir, exist_ok=True)
-
-exe_names = [os.path.join(appdir, target) for target in targets]
-
-
-def clean_up(epth):
-    print("Removing test files and directories")
-
-    assert os.path.isfile(epth), f"{os.path.basename(epth)} does not exist"
-    print("Removing " + os.path.basename(epth))
-    os.remove(epth)
-
 
 @pytest.mark.base
 @pytest.mark.parametrize("target", targets)
-def test_compile(target):
+def test_compile(module_tmpdir, target):
+    bin_dir = module_tmpdir / "bin"
     assert (
         pymake.build_apps(
-            target, download_dir=dstpth, appdir=appdir, verbose=True
+            str(bin_dir / target),
+            download_dir=str(module_tmpdir),
+            appdir=str(bin_dir),
+            verbose=True,
         )
         == 0
     ), f"could not compile {target}"
-
-
-@pytest.mark.base
-@pytest.mark.parametrize("epth", exe_names)
-def test_clean_up(epth):
-    clean_up(epth)
-
-
-@pytest.mark.base
-def test_finalize():
-    if os.path.isdir(dstpth):
-        shutil.rmtree(dstpth)
-
-
-if __name__ == "__main__":
-    for target in targets:
-        test_compile(target)
-    for exe_name in exe_names:
-        test_clean_up(exe_name)
-    test_finalize()

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -1,46 +1,47 @@
 import os
 import shutil
-import sys
+from platform import system
+from pathlib import Path
 
 import flopy
 import pytest
 
 import pymake
 
-# define program data
-target = "mp6"
-if sys.platform.lower() == "win32":
-    target += ".exe"
 
-# get program dictionary
-prog_dict = pymake.usgs_program_data.get_target(target)
-
-# set up paths
-dstpth = os.path.join(f"temp_{os.path.basename(__file__).replace('.py', '')}")
-if not os.path.exists(dstpth):
-    os.makedirs(dstpth, exist_ok=True)
-
-mp6pth = os.path.join(dstpth, prog_dict.dirname)
-expth = os.path.join(mp6pth, "example-run")
-
-sim_files = [f"EXAMPLE-{n}.mpsim" for n in range(1, 10)]
-
-exe_name = target
-srcpth = os.path.join(mp6pth, prog_dict.srcdir)
-epth = os.path.abspath(os.path.join(dstpth, target))
-
-pm = pymake.Pymake(verbose=True)
-pm.target = target
-pm.appdir = dstpth
+@pytest.fixture(scope="module")
+def target(module_tmpdir) -> Path:
+    name = "mp6"
+    ext = ".exe" if system() == "Windows" else ""
+    return module_tmpdir / f"{name}{ext}"
 
 
-def update_files(fn):
+@pytest.fixture(scope="module")
+def prog_data(target) -> dict:
+    return pymake.usgs_program_data.get_target(target.name)
+
+
+@pytest.fixture(scope="module")
+def workspace(module_tmpdir, prog_data) -> Path:
+    return module_tmpdir / prog_data.dirname
+
+
+@pytest.fixture(scope="module")
+def pm(module_tmpdir, target) -> pymake.Pymake:
+    pm = pymake.Pymake(verbose=True)
+    pm.target = str(target)
+    pm.appdir = module_tmpdir
+    yield pm
+    pm.finalize()
+
+
+def update_files(fn, workspace):
     # rename a few files for linux
     replace_files = ["example-6", "example-7", "example-8"]
     for rf in replace_files:
         if rf in fn.lower():
-            fname1 = os.path.join(expth, f"{rf}.locations")
-            fname2 = os.path.join(expth, f"{rf}_mod.locations")
+            fname1 = workspace / f"{rf}.locations"
+            fname2 = workspace / f"{rf}_mod.locations"
             print(
                 "copy {} to {}".format(
                     os.path.basename(fname1), os.path.basename(fname2)
@@ -49,7 +50,7 @@ def update_files(fn):
             shutil.copy(fname1, fname2)
             print(f"deleting {os.path.basename(fname1)}")
             os.remove(fname1)
-            fname1 = os.path.join(expth, f"{rf.upper()}.locations")
+            fname1 = workspace / f"{rf.upper()}.locations"
             print(
                 "renmae {} to {}".format(
                     os.path.basename(fname2), os.path.basename(fname1)
@@ -58,62 +59,31 @@ def update_files(fn):
             os.rename(fname2, fname1)
 
 
-def run_modpath6(fn):
-    success = False
-    if os.path.exists(epth):
-        update_files(fn)
-        # run the model
-        print(f"running model...{fn}")
-        success, buff = flopy.run_model(epth, fn, model_ws=expth, silent=False)
-    return success
-
-
-def clean_up():
-    print("Removing test files and directories")
-
-    # finalize pymake object
-    pm.finalize()
-
-    if os.path.isfile(epth):
-        print("Removing " + target)
-        os.remove(epth)
-
-    dirs_temp = [dstpth]
-    for d in dirs_temp:
-        if os.path.isdir(d):
-            shutil.rmtree(d)
-
-    return
-
-
+@pytest.mark.dependency(name="download")
 @pytest.mark.base
-def test_download():
-    if os.path.isdir(mp6pth):
-        shutil.rmtree(mp6pth)
-
-    pm.download_target(target, download_path=dstpth)
+def test_download(pm, module_tmpdir, target):
+    pm.download_target(target, download_path=module_tmpdir)
     assert pm.download, f"could not download {target} distribution"
 
 
+@pytest.mark.dependency(name="build", depends=["download"])
 @pytest.mark.base
-def test_compile():
+def test_compile(pm, target):
     assert pm.build() == 0, f"could not compile {target}"
 
 
+@pytest.mark.dependency(name="test", depends=["build"])
 @pytest.mark.regression
-@pytest.mark.parametrize("fn", sim_files)
-def test_modpath6(fn):
-    assert run_modpath6(fn), f"could not run {fn}"
+@pytest.mark.parametrize(
+    "namefile", [f"EXAMPLE-{n}.mpsim" for n in range(1, 10)]
+)
+def test_mp6(namefile, workspace, target):
+    example_ws = workspace / "example-run"
+    if not (example_ws / namefile).is_file():
+        pytest.skip(f"Namefile {namefile} does not exist")
 
-
-@pytest.mark.base
-def test_clean_up():
-    clean_up()
-
-
-if __name__ == "__main__":
-    test_download()
-    test_compile()
-    for fn in sim_files:
-        run_modpath6(fn)
-    test_clean_up()
+    update_files(namefile, example_ws)
+    success, _ = flopy.run_model(
+        target, namefile, model_ws=example_ws, silent=False
+    )
+    assert success, f"could not run {namefile}"

--- a/autotest/test_mt3d.py
+++ b/autotest/test_mt3d.py
@@ -1,227 +1,171 @@
 import os
-import shutil
 import sys
+from pathlib import Path
 
 import flopy
 import pytest
 
 import pymake
 
-# define program data
-target = "mt3dusgs"
 
-# get program dictionary
-prog_dict = pymake.usgs_program_data.get_target(target)
-
-# set up paths
-dstpth = os.path.join(f"temp_{os.path.basename(__file__).replace('.py', '')}")
-if not os.path.exists(dstpth):
-    os.makedirs(dstpth, exist_ok=True)
-
-mtusgsver = prog_dict.version
-mtusgspth = os.path.join(dstpth, prog_dict.dirname)
-emtusgs = os.path.abspath(os.path.join(dstpth, target))
-
-mfnwt_target = "mfnwt"
-temp_dict = pymake.usgs_program_data().get_target(mfnwt_target)
-emfnwt = os.path.abspath(os.path.join(dstpth, mfnwt_target))
-
-mf6_target = "mf6"
-temp_dict = pymake.usgs_program_data().get_target(mf6_target)
-emf6 = os.path.abspath(os.path.join(dstpth, mf6_target))
-
-if sys.platform.lower() == "win32":
-    ext = ".exe"
-    emtusgs += ext
-    emfnwt += ext
-    emf6 += ext
-
-# example path
-expth = os.path.join(mtusgspth, "data")
-
-# set up pths and exes
-epths = [emtusgs, emfnwt, emf6]
-
-pm = pymake.Pymake(verbose=True)
-pm.appdir = dstpth
-pm.makeclean = True
-
-sim_dirs = [
-    "2ED5EAs",
-    "CTS1",
-    "CTS2",
-    "CTS3",
-    "CTS4",
-    "Keating",
-    "Keating_UZF",
-    "SFT_CrnkNic",
-    # "UZT_Disp_Lamb01_TVD",
-    # "UZT_Disp_Lamb1",
-    # "UZT_Disp_Lamb10",
-    # "UZT_NonLin",
-    "gwt",
-    "lkt",
-    "p01SpatialStresses(mf6)",
-]
-
-# remove after MODFLOW 6 v6.1.2 release
-for exclude in (
-    "Keating",
-    "Keating_UZF",
-):
-    if exclude in sim_dirs:
-        sim_dirs.remove(exclude)
-
-# CI fix
-if pymake.usgs_program_data().get_version(mfnwt_target) == "1.2.0":
-    for exclude in (
-        "UZT_NonLin",
-        "UZT_Disp_Lamb01_TVD",
-        "UZT_Disp_Lamb1",
-        "UZT_Disp_Lamb10",
-    ):
-        if exclude in sim_dirs:
-            sim_dirs.remove(exclude)
+@pytest.fixture(scope="module")
+def target(module_tmpdir) -> Path:
+    return module_tmpdir / "mt3dusgs"
 
 
-def run_mt3dusgs(temp_dir):
+@pytest.fixture(scope="module")
+def prog_data(target) -> dict:
+    return pymake.usgs_program_data.get_target(target.name)
+
+
+@pytest.fixture(scope="module")
+def workspace(module_tmpdir, prog_data) -> Path:
+    return module_tmpdir / prog_data.dirname
+
+
+@pytest.fixture(scope="module")
+def pm(module_tmpdir) -> pymake.Pymake:
+    pm = pymake.Pymake(verbose=True)
+    pm.appdir = str(module_tmpdir)
+    pm.makeclean = True
+    yield pm
+    pm.finalize()
+
+
+def run_mt3dusgs(workspace, mt3dms_exe, mfnwt_exe, mf6_exe):
     success = False
-    if os.path.exists(emtusgs):
-        model_ws = os.path.join(expth, temp_dir)
+    model_ws = workspace
 
-        files = [
-            f
-            for f in os.listdir(model_ws)
-            if os.path.isfile(os.path.join(model_ws, f))
-        ]
+    files = [
+        f
+        for f in os.listdir(model_ws)
+        if os.path.isfile(os.path.join(model_ws, f))
+    ]
 
-        mf_nam = None
-        mt_nam = None
-        flow_model = None
-        for f in files:
-            if "_mf.nam" in f.lower():
-                mf_nam = f
-                flow_model = "mfnwt"
-            if "_mt.nam" in f.lower():
-                mt_nam = f
-            if f == "mfsim.nam":
-                mf_nam = f
-                flow_model = "mf6"
+    mf_nam = None
+    mt_nam = None
+    flow_model = None
+    for f in files:
+        if "_mf.nam" in f.lower():
+            mf_nam = f
+            flow_model = "mfnwt"
+        if "_mt.nam" in f.lower():
+            mt_nam = f
+        if f == "mfsim.nam":
+            mf_nam = f
+            flow_model = "mf6"
 
-        msg = f"A MODFLOW name file not present in {model_ws}"
-        assert mf_nam is not None, msg
+    msg = f"A MODFLOW name file not present in {model_ws}"
+    assert mf_nam is not None, msg
 
-        msg = f"A MT3D-USGS name file not present in {model_ws}"
-        assert mt_nam is not None, msg
+    msg = f"A MT3D-USGS name file not present in {model_ws}"
+    assert mt_nam is not None, msg
 
-        # run the flow model
-        msg = f"{emfnwt}"
-        if mf_nam is not None:
-            msg += f" {os.path.basename(mf_nam)}"
-        if flow_model == "mfnwt":
-            nam = mf_nam
-            eapp = emfnwt
-        elif flow_model == "mf6":
-            nam = None
-            eapp = emf6
-        success, buff = flopy.run_model(
-            eapp, nam, model_ws=model_ws, silent=False
+    # run the flow model
+    msg = f"{mfnwt_exe}"
+    if mf_nam is not None:
+        msg += f" {os.path.basename(mf_nam)}"
+    if flow_model == "mfnwt":
+        nam = mf_nam
+        eapp = mfnwt_exe
+    elif flow_model == "mf6":
+        nam = None
+        eapp = mf6_exe
+    success, _ = flopy.run_model(eapp, nam, model_ws=model_ws, silent=False)
+
+    # run the MT3D-USGS model
+    if success:
+        print(f"running model...{mt_nam}")
+        success, _ = flopy.run_model(
+            mt3dms_exe,
+            mt_nam,
+            model_ws=model_ws,
+            silent=False,
+            normal_msg="Program completed.",
         )
-
-        # run the MT3D-USGS model
-        if success:
-            print(f"running model...{mt_nam}")
-            success, buff = flopy.run_model(
-                emtusgs,
-                mt_nam,
-                model_ws=model_ws,
-                silent=False,
-                normal_msg="Program completed.",
-            )
 
     return success
 
 
-def clean_up():
-    print("Removing test files and directories")
-
-    # finalize pymake object
-    pm.finalize()
-
-    for epth in epths:
-        if os.path.isfile(epth):
-            print("Removing '" + epth + "'")
-            os.remove(epth)
-
-    dirs_temp = (dstpth,)
-    for d in dirs_temp:
-        if os.path.isdir(d):
-            shutil.rmtree(d)
-
-    return
-
-
+@pytest.mark.dependency(name="download_mt3dms")
 @pytest.mark.base
-def test_download_mt3dms():
-    # Remove the existing target download directory if it exists
-    if os.path.isdir(mtusgspth):
-        shutil.rmtree(mtusgspth)
-
+def test_download_mt3dms(pm, module_tmpdir):
     pm.target = "mt3dms"
-    pm.download_target(pm.target, download_path=dstpth)
+    pm.download_target(pm.target, download_path=module_tmpdir)
     assert pm.download, f"could not download {pm.target} distribution"
 
 
+@pytest.mark.dependency(name="build_mt3dms", depends=["download_mt3dms"])
 @pytest.mark.base
-def test_compile_mt3dms():
+def test_compile_mt3dms(pm):
     assert pm.build() == 0, f"could not compile {pm.target}"
 
 
+@pytest.mark.dependency(name="download")
 @pytest.mark.base
-def test_download():
-    # Remove the existing target download directory if it exists
-    if os.path.isdir(mtusgspth):
-        shutil.rmtree(mtusgspth)
-
-    # reset the Pymake object for target
-    pm.reset(target)
-
-    # download the target
-    pm.download_target(target, download_path=dstpth)
+def test_download(pm, module_tmpdir, target):
+    pm.reset(str(target))
+    pm.download_target(target, download_path=module_tmpdir)
     assert pm.download, f"could not download {target} distribution"
 
 
+@pytest.mark.dependency(name="build", depends=["download"])
 @pytest.mark.base
-def test_compile():
+def test_compile(pm, target):
     assert pm.build() == 0, f"could not compile {target}"
 
 
 @pytest.mark.regression
 @pytest.mark.skipif(sys.platform == "darwin", reason="do not run on OSX")
-def test_download_exes():
-    pymake.getmfexes(dstpth, exes=("mfnwt", "mf6"), verbose=True)
-    return
+def test_download_exes(module_tmpdir):
+    pymake.getmfexes(module_tmpdir, exes=("mfnwt", "mf6"), verbose=True)
 
 
 @pytest.mark.regression
 @pytest.mark.skipif(sys.platform == "darwin", reason="do not run on OSX")
 @pytest.mark.skipif(sys.platform == "win32", reason="do not run on Windows")
-@pytest.mark.parametrize("ws", sim_dirs)
-def test_mt3dusgs(ws):
-    assert run_mt3dusgs(ws), f"could not run {ws}"
+@pytest.mark.parametrize(
+    "ws",
+    [
+        "2ED5EAs",
+        "CTS1",
+        "CTS2",
+        "CTS3",
+        "CTS4",
+        "Keating",
+        "Keating_UZF",
+        "SFT_CrnkNic",
+        # "UZT_Disp_Lamb01_TVD",
+        # "UZT_Disp_Lamb1",
+        # "UZT_Disp_Lamb10",
+        # "UZT_NonLin",
+        "gwt",
+        "lkt",
+        "p01SpatialStresses(mf6)",
+    ],
+)
+def test_mt3dusgs(module_tmpdir, workspace, ws, target):
+    mfnwt_exe = module_tmpdir / "mfnwt"
+    if pymake.usgs_program_data().get_version(mfnwt_exe) == "1.2.0":
+        exclude = [
+            "UZT_NonLin",
+            "UZT_Disp_Lamb01_TVD",
+            "UZT_Disp_Lamb1",
+            "UZT_Disp_Lamb10",
+        ]
+        if ws in exclude:
+            pytest.skip(reason="excluding {ws}")
 
+    exclude = [
+        "Keating",
+        "Keating_UZF",
+    ]
+    if ws in exclude:
+        pytest.skip(reason="excluding {ws}")
 
-@pytest.mark.base
-def test_clean_up():
-    clean_up()
-
-
-if __name__ == "__main__":
-    test_download_mt3dms()
-    test_compile_mt3dms()
-    test_download_exes()
-    test_download()
-    test_compile()
-    for dn in sim_dirs:
-        run_mt3dusgs(dn)
-    test_clean_up()
+    assert run_mt3dusgs(
+        workspace / "data" / ws,
+        target,
+        mfnwt_exe,
+        module_tmpdir / "mf6",
+    ), f"could not run {ws}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ test = [
     "pytest-benchmark",
     "pytest-cases",
     "pytest-cov",
+    "pytest-dependency",
     "pytest-dotenv",
     "pytest-virtualenv",
     "pytest-xdist",


### PR DESCRIPTION
- switch to [`awvwgk/setup-fortran`](https://github.com/awvwgk/setup-fortran) to install Intel compilers
  - temporarily set `SETVARS_COMPLETED` and `CXX` manually until action patched
- use pytest temp dir fixtures in autotests
- add `pytest-dependency` to test dep group in `pyproject.toml`
- add `dependency` marker to `autotest/pytest.ini` to avoid warnings