### PR TITLE
ci: use setup-fortran, use major version tags for actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,27 +27,19 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Intel Fortran Classic
-        uses: awvwgk/setup-fortran@main
+        uses: awvwgk/setup-fortran@v1
         with:
           compiler: intel-classic
-          version: 2021.7.0
-      
-      - name: Set SETVARS_COMPLETED (temporary)
-        run: echo "SETVARS_COMPLETED=1" >> $GITHUB_ENV
-
-      - name: Set CXX (temporary)
-        if: runner.os == 'Windows'
-        run: |
-          echo "CXX=icl" >> $GITHUB_ENV
+          version: "2021.7"
 
       - name: Setup Graphviz
         if: runner.os == 'Linux'
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Set up Python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install python packages
         run: |
@@ -83,6 +75,6 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3
         with:
           file: ./autotest/coverage.xml

--- a/.github/workflows/pymake-gcc.yml
+++ b/.github/workflows/pymake-gcc.yml
@@ -17,7 +17,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        include:
+          # test latest gcc and python
+          - {os: ubuntu-latest, gcc: 13, python: "3.11"}
+          - {os: windows-latest, gcc: 12, python: "3.11"}
+          - {os: macos-latest, gcc: 13, python: "3.11"}
+          # test latest gcc and previous python
+          - {os: ubuntu-latest, gcc: 13, python: "3.11"}
+          - {os: ubuntu-latest, gcc: 13, python: "3.10"}
+          - {os: ubuntu-latest, gcc: 13, python: 3.9}
+          - {os: ubuntu-latest, gcc: 13, python: 3.8}
+          # test latest python and previous gcc
+          - {os: ubuntu-latest, gcc: 12, python: "3.11"}
+          - {os: ubuntu-latest, gcc: 11, python: "3.11"}
     defaults:
       run:
         shell: bash
@@ -31,9 +43,9 @@ jobs:
         uses: ts-graphviz/setup-graphviz@v1
 
       - name: Setup Python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python }}
 
       - name: Install python packages
         run: |
@@ -41,127 +53,28 @@ jobs:
           pip install ".[test]"
 
       - name: Setup GNU Fortran
-        uses: awvwgk/setup-fortran@main
+        uses: awvwgk/setup-fortran@v1
         with:
           compiler: gcc
-          version: 11
-
-      - name: Set CXX (temporary)
-        if: runner.os == 'Windows'
-        run: |
-          echo "CXX=g++" >> $GITHUB_ENV
+          version: ${{ matrix.gcc }}
 
       - name: Download examples for pytest runs
-        run: |
-          .github/common/download-examples.sh
+        run: .github/common/download-examples.sh
 
       - name: Run pytest
         working-directory: ./autotest
         run: |
-          pytest -v --dist=loadfile -n=auto -m="base or regression" --durations=0 --cov=pymake --cov-report=xml --basetemp=pytest_temp
+          markers="base"
+          if [[ ${{ matrix.gcc }} == 13 ]]; then
+            markers="base or regression"
+          fi
+          pytest -v --dist=loadfile -n=auto --durations=0 --basetemp=pytest_temp --cov=pymake --cov-report=xml --cov-append -m "$markers"
 
       - name: Print coverage report before upload
         working-directory: ./autotest
-        run: |
-          coverage report
+        run: coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3
         with:
           file: ./autotest/coverage.xml
-
-  pymakeCI-gcc-prev:
-    name: pymake CI GCC 9 and 8
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        gcc-version: [ 9, 8 ]
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Setup Graphviz
-        uses: ts-graphviz/setup-graphviz@v1
-
-      - name: Set up Python
-        uses: actions/setup-python@v4.7.1
-        with:
-          python-version: "3.10"
-
-      - name: Install python packages
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[test]"
-
-      - name: Setup symbolic link to gfortran on Linux
-        run: |
-          sudo ln -fs /usr/bin/gfortran-${{ matrix.gcc-version }} /usr/local/bin/gfortran
-          sudo ln -fs /usr/bin/gcc-${{ matrix.gcc-version }} /usr/local/bin/gcc
-          sudo ln -fs /usr/bin/g++-${{ matrix.gcc-version }} /usr/local/bin/g++
-
-      - name: Print GNU compiler versions
-        run: |
-          gfortran --version
-          gcc --version
-          g++ --version
-
-      - name: Download examples for pytest runs
-        run: |
-          .github/common/download-examples.sh
-
-      - name: Run pytest
-        working-directory: ./autotest
-        run: |
-          pytest -v --dist=loadfile -n=auto -m="base" --durations=0 --cov=pymake --cov-report=xml
-
-      - name: Print coverage report before upload
-        working-directory: ./autotest
-        run: |
-          coverage report
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.4
-        with:
-          file: ./autotest/coverage.xml
-
-  pymakeCI-python-prev:
-    name: pymake CI with previous python versions
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [ 3.9, 3.8 ]
-    defaults:
-      run:
-        shell: bash
-
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@v4
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.7.1
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install python packages
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[test]"
-
-      - name: Install GNU Fortran
-        uses: modflowpy/install-gfortran-action@v1
-
-      - name: Download examples for pytest runs
-        run: |
-          .github/common/download-examples.sh
-
-      - name: Run pytest
-        working-directory: ./autotest
-        run: |
-          pytest -v --dist=loadfile -n=auto -m="base" --durations=0

--- a/.github/workflows/pymake-linting-install.yml
+++ b/.github/workflows/pymake-linting-install.yml
@@ -22,9 +22,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
@@ -70,14 +70,13 @@ jobs:
 
     steps:
 
-      # check out repo
       - name: Checkout pymake repo
         uses: actions/checkout@v4
 
       - name: Setup Python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Upgrade pip and install build and twine
         run: |

--- a/.github/workflows/pymake-requests.yml
+++ b/.github/workflows/pymake-requests.yml
@@ -23,9 +23,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4.7.1
+        uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install python packages
         run: |
@@ -49,6 +49,6 @@ jobs:
           coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v3
         with:
           file: ./autotest/coverage.xml

--- a/.github/workflows/pymake-rtd.yml
+++ b/.github/workflows/pymake-rtd.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Trigger RTDs build
         if: github.ref == 'refs/heads/master'
-        uses: dfm/rtds-action@v1.1.0
+        uses: dfm/rtds-action@v1
         with:
           webhook_url: ${{ secrets.RTDS_WEBHOOK_URL }}
           webhook_token: ${{ secrets.RTDS_WEBHOOK_TOKEN }}


### PR DESCRIPTION
* use `fortran-lang/setup-fortran` instead of `modflowpy/install-gfortran-action` (latter to be retired soon)
* use major version instead of full version tags for actions (less upkeep, fewer dependabot PRs)
* consolidate gcc test jobs in single matrix
* test gcc 11-13
* test python 3.11