### PR TITLE
refactor: support python3.12, various updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Intel Fortran Classic
-        uses: awvwgk/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@v1
         with:
           compiler: intel-classic
           version: "2021.7"
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install python packages
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 7 * * *' # run at 7 AM UTC every day
   push:
-    branches: 
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/pymake-gcc.yml
+++ b/.github/workflows/pymake-gcc.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 7 * * *' # run at 7 AM UTC every day
   push:
-    branches: 
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/pymake-gcc.yml
+++ b/.github/workflows/pymake-gcc.yml
@@ -19,17 +19,17 @@ jobs:
       matrix:
         include:
           # test latest gcc and python
-          - {os: ubuntu-latest, gcc: 13, python: "3.11"}
-          - {os: windows-latest, gcc: 12, python: "3.11"}
-          - {os: macos-latest, gcc: 13, python: "3.11"}
+          - {os: ubuntu-latest, gcc: 13, python: "3.12"}
+          - {os: windows-latest, gcc: 13, python: "3.12"}
+          - {os: macos-latest, gcc: 13, python: "3.12"}
           # test latest gcc and previous python
           - {os: ubuntu-latest, gcc: 13, python: "3.11"}
           - {os: ubuntu-latest, gcc: 13, python: "3.10"}
           - {os: ubuntu-latest, gcc: 13, python: 3.9}
           - {os: ubuntu-latest, gcc: 13, python: 3.8}
           # test latest python and previous gcc
-          - {os: ubuntu-latest, gcc: 12, python: "3.11"}
-          - {os: ubuntu-latest, gcc: 11, python: "3.11"}
+          - {os: ubuntu-latest, gcc: 12, python: "3.12"}
+          - {os: ubuntu-latest, gcc: 11, python: "3.12"}
     defaults:
       run:
         shell: bash
@@ -53,7 +53,7 @@ jobs:
           pip install ".[test]"
 
       - name: Setup GNU Fortran
-        uses: awvwgk/setup-fortran@v1
+        uses: fortran-lang/setup-fortran@v1
         with:
           compiler: gcc
           version: ${{ matrix.gcc }}

--- a/.github/workflows/pymake-linting-install.yml
+++ b/.github/workflows/pymake-linting-install.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Setup Graphviz
         uses: ts-graphviz/setup-graphviz@v1
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Upgrade pip and install build and twine
         run: |

--- a/.github/workflows/pymake-linting-install.yml
+++ b/.github/workflows/pymake-linting-install.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 3 * * 3' # run at 3 AM UTC every Wednesday
   push:
-    branches: 
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/pymake-requests.yml
+++ b/.github/workflows/pymake-requests.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 7 * * *' # run at 7 AM UTC every day
   push:
-    branches: 
-      - master
   pull_request:
     branches:
       - master

--- a/.github/workflows/pymake-requests.yml
+++ b/.github/workflows/pymake-requests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
 
       - name: Install python packages
         run: |

--- a/.github/workflows/pymake-rtd.yml
+++ b/.github/workflows/pymake-rtd.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: '0 3 * * 3' # run at 3 AM UTC every Wednesday
   push:
-    branches: 
-      - master
   pull_request:
     branches:
       - master

--- a/.gitignore
+++ b/.gitignore
@@ -57,8 +57,9 @@ docs/_build/
 # PyBuilder
 target/
 
-# PyCharm
+# IDEs
 .idea/
+.vscode/
 
 # files in the autotest directory
 autotest/temp*/
@@ -73,3 +74,5 @@ Dependencies
 # files in the doc directory
 docs/source/
 
+# local python environments
+venv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Hydrology",
 ]
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ test = [
     "pytest-cov",
     "pytest-dependency",
     "pytest-dotenv",
-    "pytest-virtualenv",
     "pytest-xdist",
     "appdirs",
     "matplotlib",


### PR DESCRIPTION
* fix `awvwgk/setup-fortran` -> `fortran-lang/setup-fortran`
* remove `pytest-virtualenv` testing dependency
* add python 3.12 classifier in `pyproject.toml`
* update CI workflows to use python 3.12
* add IDE/venv folders to `.gitignore`