### PR TITLE
chore(format): add isort rule, split long comment lines

### DIFF
--- a/pymake/pymake_base.py
+++ b/pymake/pymake_base.py
@@ -1192,8 +1192,8 @@ def _create_win_batch(
     # open the batch file
     f = open(batchfile, "w")
 
-    # only write the compilervars batch command to batchfile if env vars aren't already configured
-    # https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html
+    # only write the command to batchfile if env vars aren't already configured
+    # https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html  # noqa: E501
     if os.environ.get("SETVARS_COMPLETED") != "1":
         line = "call " + intel_setvars + "\n"
         f.write(line)

--- a/pymake/pymake_base.py
+++ b/pymake/pymake_base.py
@@ -1193,7 +1193,6 @@ def _create_win_batch(
     f = open(batchfile, "w")
 
     # only write the command to batchfile if env vars aren't already configured
-    # https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows.html  # noqa: E501
     if os.environ.get("SETVARS_COMPLETED") != "1":
         line = "call " + intel_setvars + "\n"
         f.write(line)

--- a/pymake/utils/_usgs_src_update.py
+++ b/pymake/utils/_usgs_src_update.py
@@ -346,14 +346,14 @@ def _update_mfusg_gsi_files(srcdir, fc, cc, arch, double):
 
     """
     tags = {
-        "FMTARG = 'BINARY'": "FMTARG = 'UNFORMATTED'\n        ACCARG = 'STREAM'",
+        "FMTARG = 'BINARY'": "FMTARG = 'UNFORMATTED'\n        ACCARG = 'STREAM'",  # noqa: E501
         ",SHARED,ACCESS='SEQUENTIAL'": ",ACCESS='SEQUENTIAL'",
         "FORM=FMTARG,SHARED,": "FORM=FMTARG,",
         ",BUFFERED='YES',": ",",
         ", BUFFERED='NO')": ")",
         ",SHARE = 'DENYNONE'": ",",
         ", SHARE = 'DENYNONE',": ",",
-        "FORM='FORMATTED',ACCESS='SEQUENTIAL',": "FORM='FORMATTED',ACCESS='SEQUENTIAL'",
+        "FORM='FORMATTED',ACCESS='SEQUENTIAL',": "FORM='FORMATTED',ACCESS='SEQUENTIAL'",  # noqa: E501
     }
 
     fpth = pl.Path(srcdir) / "glo2basu1.f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ include = [
 ]
 
 [tool.ruff.lint]
+select = ["F", "E", "I001"]
 ignore = [
     "E402", # module level import not at top of file
     "E712", # Avoid equality comparisons to `True`


### PR DESCRIPTION
* extend default rules in `pyproject.toml`
* apply import sorting
* split or ignore comment lines where needed to fully observe E501