### PR TITLE
ci(mac): use classic linker for gridgen with gnu compilers

### DIFF
--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -1,6 +1,6 @@
-import os
 import pathlib as pl
 import subprocess
+from os import environ
 from platform import system
 
 import pytest
@@ -30,8 +30,10 @@ def pm(module_tmpdir, target) -> pymake.Pymake:
     pm = pymake.Pymake(verbose=True)
     pm.target = str(target)
     pm.appdir = str(module_tmpdir)
-    pm.cc = os.environ.get("CXX", "g++")
-    pm.fc = os.environ.get("FC", "gfortran")
+    pm.cc = environ.get("CXX", "g++")
+    pm.fc = environ.get("FC", "gfortran")
+    if system() == "Darwin":
+        pm.syslibs = "-Wl,-ld_classic"
     pm.inplace = True
     pm.makeclean = True
     yield pm


### PR DESCRIPTION
* fix gridgen gcc/g++ compile errors with `-Wl,-ld_classic` to select the classic linker
  * https://forums.developer.apple.com/forums/thread/737707
* there are still failures building gridgen with intel on macos-14, it looks like a failure to find the appropriate header files &mdash; and there is some separate issue building GSFLOW