### PR TITLE
ci(macos): use xcode clt 14.3.1 for intel c++ compiler compatibility

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,11 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        if: runner.os == 'macOS'
+        with:
+          xcode-version: "14.3.1"
+
       - name: Setup ${{ env.FC }} ${{ env.FC_V }}
         uses: fortran-lang/setup-fortran@v1
         with:


### PR DESCRIPTION
* gridgen build fails with newer versions of xcode command line tools