### PR TITLE
chore: reformat Python code with line length = 88

### DIFF
--- a/autotest/test_mf2005.py
+++ b/autotest/test_mf2005.py
@@ -91,7 +91,5 @@ def test_mf2005(namefile, workspace, target):
     if not (example_ws / namefile).is_file():
         pytest.skip(f"{namefile} does not exist")
 
-    success, _ = flopy.run_model(
-        target, namefile, model_ws=example_ws, silent=False
-    )
+    success, _ = flopy.run_model(target, namefile, model_ws=example_ws, silent=False)
     assert success, f"could not run {namefile} with {target}"

--- a/autotest/test_mp6.py
+++ b/autotest/test_mp6.py
@@ -79,16 +79,12 @@ def test_compile(pm, target):
 @pytest.mark.dependency(name="test", depends=["build"])
 @pytest.mark.xdist_group(TARGET_NAME)
 @pytest.mark.regression
-@pytest.mark.parametrize(
-    "namefile", [f"EXAMPLE-{n}.mpsim" for n in range(1, 10)]
-)
+@pytest.mark.parametrize("namefile", [f"EXAMPLE-{n}.mpsim" for n in range(1, 10)])
 def test_mp6(namefile, workspace, target):
     example_ws = workspace / "example-run"
     if not (example_ws / namefile).is_file():
         pytest.skip(f"Namefile {namefile} does not exist")
 
     update_files(namefile, example_ws)
-    success, _ = flopy.run_model(
-        target, namefile, model_ws=example_ws, silent=False
-    )
+    success, _ = flopy.run_model(target, namefile, model_ws=example_ws, silent=False)
     assert success, f"could not run {namefile}"

--- a/autotest/test_mp7.py
+++ b/autotest/test_mp7.py
@@ -40,9 +40,7 @@ def pm(module_tmpdir, target) -> pymake.Pymake:
 
 def replace_data(dpth):
     fpths = [
-        name
-        for name in os.listdir(dpth)
-        if os.path.isfile(os.path.join(dpth, name))
+        name for name in os.listdir(dpth) if os.path.isfile(os.path.join(dpth, name))
     ]
     repl = False
     if "ex01_mf2005.dis" in fpths:
@@ -137,9 +135,7 @@ def run_modpath7(namefile, mp7_exe, mf2005_exe, mfusg_exe, mf6_exe):
 
     if success:
         fpth = os.path.basename(namefile)
-        success, _ = flopy.run_model(
-            mp7_exe, fpth, model_ws=model_ws, silent=False
-        )
+        success, _ = flopy.run_model(mp7_exe, fpth, model_ws=model_ws, silent=False)
 
     return success
 
@@ -163,14 +159,10 @@ def test_compile(pm, target):
 @pytest.mark.xdist_group(TARGET_NAME)
 @pytest.mark.regression
 def test_download_exes(module_tmpdir):
-    pymake.getmfexes(
-        str(module_tmpdir), exes=("mf2005", "mfusg", "mf6"), verbose=True
-    )
+    pymake.getmfexes(str(module_tmpdir), exes=("mf2005", "mfusg", "mf6"), verbose=True)
 
 
-@pytest.mark.dependency(
-    name="test", depends=["download", "download_exes", "build"]
-)
+@pytest.mark.dependency(name="test", depends=["download", "download_exes", "build"])
 @pytest.mark.xdist_group(TARGET_NAME)
 @pytest.mark.regression
 @pytest.mark.parametrize(

--- a/autotest/test_mt3dusgs.py
+++ b/autotest/test_mt3dusgs.py
@@ -42,9 +42,7 @@ def run_mt3dusgs(workspace, mt3dms_exe, mfnwt_exe, mf6_exe):
     model_ws = workspace
 
     files = [
-        f
-        for f in os.listdir(model_ws)
-        if os.path.isfile(os.path.join(model_ws, f))
+        f for f in os.listdir(model_ws) if os.path.isfile(os.path.join(model_ws, f))
     ]
 
     mf_nam = None

--- a/autotest/test_requests.py
+++ b/autotest/test_requests.py
@@ -163,8 +163,7 @@ def test_mfexes_download_and_unzip_and_zip(function_tmpdir):
     success = pymake.zip_all(
         str(zip_pth),
         file_pths=[
-            os.path.join(function_tmpdir, e)
-            for e in os.listdir(function_tmpdir)
+            os.path.join(function_tmpdir, e) for e in os.listdir(function_tmpdir)
         ],
     )
     assert success, "could not create zipfile using file names"
@@ -178,9 +177,7 @@ def test_mfexes_download_and_unzip_and_zip(function_tmpdir):
     # zip up exe's using directories and a pattern
     zip_pth = function_tmpdir / "ziptest03.zip"
     print(f"creating '{zip_pth}'")
-    success = pymake.zip_all(
-        str(zip_pth), dir_pths=function_tmpdir, patterns="mf"
-    )
+    success = pymake.zip_all(str(zip_pth), dir_pths=function_tmpdir, patterns="mf")
     assert success, "could not create zipfile using directories and a pattern"
 
     # zip up exe's using files and directories
@@ -189,8 +186,7 @@ def test_mfexes_download_and_unzip_and_zip(function_tmpdir):
     success = pymake.zip_all(
         str(zip_pth),
         file_pths=[
-            os.path.join(function_tmpdir, e)
-            for e in os.listdir(function_tmpdir)
+            os.path.join(function_tmpdir, e) for e in os.listdir(function_tmpdir)
         ],
         dir_pths=function_tmpdir,
     )
@@ -283,9 +279,7 @@ def test_usgsprograms_export_json(module_tmpdir):
 def test_usgsprograms_load_json_error(module_tmpdir):
     fpth = os.path.join(module_tmpdir, "code.test.error.json")
     my_dict = {"mf2005": {"bad": 12, "key": True}}
-    pymake.usgs_program_data.export_json(
-        fpth=fpth, prog_data=my_dict, update=False
-    )
+    pymake.usgs_program_data.export_json(fpth=fpth, prog_data=my_dict, update=False)
 
     with pytest.raises(KeyError):
         pymake.usgs_program_data.load_json(fpth=fpth)

--- a/pymake/plot/dependency_graphs.py
+++ b/pymake/plot/dependency_graphs.py
@@ -119,9 +119,7 @@ def _add_pydot_edges(graph, node_dict, edge_set, n, ilev, level):
                 edge_set.add(tpl)
                 edge = pydot.Edge(node_dict[n], node_dict[m])
                 graph.add_edge(edge)
-                _add_pydot_edges(
-                    graph, node_dict, edge_set, m, ilev + 1, level
-                )
+                _add_pydot_edges(graph, node_dict, edge_set, m, ilev + 1, level)
     return
 
 

--- a/pymake/pymake.py
+++ b/pymake/pymake.py
@@ -126,10 +126,7 @@ class Pymake:
             setattr(self, key, value["default"])
 
         # parse command line arguments if python is running script
-        if (
-            sys.argv[0].lower().endswith(".py")
-            or "make-program" in sys.argv[0].lower()
-        ):
+        if sys.argv[0].lower().endswith(".py") or "make-program" in sys.argv[0].lower():
             self._arg_parser()
 
         # reset select variables using passed variables
@@ -298,9 +295,7 @@ class Pymake:
                     + f"directory to zip file '{pl.Path(zip_pth).resolve()}'"
                 )
                 for idx, target in enumerate(targets):
-                    print(
-                        f" {idx + 1:>3d}. adding " + f"'{target}' to zipfile"
-                    )
+                    print(f" {idx + 1:>3d}. adding " + f"'{target}' to zipfile")
 
             # compress the compiled executables
             if not zip_all(
@@ -654,10 +649,7 @@ class Pymake:
                     fpth = os.path.join(srcdir, extrafiles)
                     extrafiles = os.path.normpath(fpth)
                 else:
-                    msg = (
-                        "invalid extrafiles format - "
-                        + "must be a list or string"
-                    )
+                    msg = "invalid extrafiles format - " + "must be a list or string"
                     raise ValueError(msg)
 
             # reset extrafiles
@@ -677,9 +669,7 @@ class Pymake:
         """
         if self.excludefiles is None:
             if self._get_base_target() in ("libmf6",):
-                self.excludefiles = [
-                    os.path.join(self.download_dir, "src", "mf6.f90")
-                ]
+                self.excludefiles = [os.path.join(self.download_dir, "src", "mf6.f90")]
         return
 
     def build(self, target=None, srcdir=None, modify_exe_name=False):
@@ -730,9 +720,7 @@ class Pymake:
         if self.fc != "none":
             if self.fflags is None:
                 optlevel = (
-                    _get_optlevel(
-                        self.target, self.fc, self.cc, self.debug, [], []
-                    )
+                    _get_optlevel(self.target, self.fc, self.cc, self.debug, [], [])
                     + " "
                 )
 
@@ -749,9 +737,7 @@ class Pymake:
         if self.cc != "none":
             if self.cflags is None:
                 optlevel = (
-                    _get_optlevel(
-                        self.target, self.fc, self.cc, self.debug, [], []
-                    )
+                    _get_optlevel(self.target, self.fc, self.cc, self.debug, [], [])
                     + " "
                 )
 
@@ -776,9 +762,7 @@ class Pymake:
                 )[1]
             )
 
-        self.target = self.update_target(
-            self.target, modify_target=modify_exe_name
-        )
+        self.target = self.update_target(self.target, modify_target=modify_exe_name)
 
         build_target = self.set_build_target_bool()
 

--- a/pymake/pymake_base.py
+++ b/pymake/pymake_base.py
@@ -635,10 +635,7 @@ def _clean_temp_files(
 
     # remove temporary directories
     if verbose:
-        msg = (
-            "\nCleaning up temporary source, object, "
-            + "and module directories..."
-        )
+        msg = "\nCleaning up temporary source, object, " + "and module directories..."
         print(msg)
     if not inplace:
         if os.path.isdir(srcdir_temp):
@@ -844,9 +841,7 @@ def _pymake_compile(
     )
 
     # set optimization levels
-    optlevel = _get_optlevel(
-        target, fc, cc, debug, fflags, cflags, verbose=verbose
-    )
+    optlevel = _get_optlevel(target, fc, cc, debug, fflags, cflags, verbose=verbose)
 
     # get fortran and c compiler switches
     tfflags = _get_fortran_flags(
@@ -1161,9 +1156,7 @@ def _create_win_batch(
                     + f"{latest_version}\\env\\vars.bat"
                 )
             else:
-                cpvars = (
-                    "C:\\Program Files (x86)\\Intel\\oneAPI\\" + "setvars.bat"
-                )
+                cpvars = "C:\\Program Files (x86)\\Intel\\oneAPI\\" + "setvars.bat"
             if not os.path.isfile(cpvars):
                 raise Exception(f"Could not find cpvars: {cpvars}")
             intel_setvars = f'"{cpvars}"'
@@ -1174,9 +1167,7 @@ def _create_win_batch(
         for ift in iflist:
             stand_alone_intel = os.environ.get(ift)
             if stand_alone_intel is not None:
-                cpvars = os.path.join(
-                    stand_alone_intel, "bin", "compilervars.bat"
-                )
+                cpvars = os.path.join(stand_alone_intel, "bin", "compilervars.bat")
                 if not os.path.isfile(cpvars):
                     raise Exception(f"Could not find cpvars: {cpvars}")
                 intel_setvars = '"' + os.path.normpath(cpvars) + '" ' + arch
@@ -1184,8 +1175,7 @@ def _create_win_batch(
     # check if either OneAPI or stand alone intel is installed
     if intel_setvars is None:
         err_msg = (
-            "OneAPI or stand alone version of Intel compilers "
-            + "is not installed"
+            "OneAPI or stand alone version of Intel compilers " + "is not installed"
         )
         raise ValueError(err_msg)
 
@@ -1205,11 +1195,7 @@ def _create_win_batch(
             searchdir.append(dirname)
 
     # write commands to build object files
-    line = (
-        "echo Creating object files to create '"
-        + os.path.basename(target)
-        + "'\n"
-    )
+    line = "echo Creating object files to create '" + os.path.basename(target) + "'\n"
     f.write(line)
     for srcfile in srcfiles:
         if srcfile.endswith(".c") or srcfile.endswith(".cpp"):
@@ -1243,11 +1229,7 @@ def _create_win_batch(
         f.write(cmd + "\n")
 
     # write commands to link
-    line = (
-        "echo Linking object files to create '"
-        + os.path.basename(target)
-        + "'\n"
-    )
+    line = "echo Linking object files to create '" + os.path.basename(target) + "'\n"
     f.write(line)
 
     # assemble the link command
@@ -1460,9 +1442,7 @@ def _create_makefile(
         for ext in cext:
             f.write(f"$(OBJDIR)/%{objext} : %{ext}\n")
             f.write("\t@mkdir -p $(@D)\n")
-            line = (
-                "\t$(CC) $(OPTLEVEL) $(CFLAGS) -c $< -o $@ " + "$(INCSWITCH)\n"
-            )
+            line = "\t$(CC) $(OPTLEVEL) $(CFLAGS) -c $< -o $@ " + "$(INCSWITCH)\n"
             f.write(f"{line}\n")
 
     # close the makefile
@@ -1483,10 +1463,7 @@ def _create_makefile(
     line += "\tdetected_OS = Windows\n"
     line += "\tOS_macro = -D_WIN32\n"
     line += "else\n"
-    line += (
-        "\tdetected_OS = $(shell sh -c 'uname 2>/dev/null "
-        + "|| echo Unknown')\n"
-    )
+    line += "\tdetected_OS = $(shell sh -c 'uname 2>/dev/null " + "|| echo Unknown')\n"
     line += "\tifeq ($(detected_OS), Darwin)\n"
     line += "\t\tOS_macro = -D__APPLE__\n"
     line += "\telse\n"
@@ -1566,9 +1543,7 @@ def _create_makefile(
         f.write(line)
 
     # optimization level
-    optlevel = _get_optlevel(
-        target, fc, cc, debug, fflags, cflags, verbose=verbose
-    )
+    optlevel = _get_optlevel(target, fc, cc, debug, fflags, cflags, verbose=verbose)
     line = "# set the optimization level (OPTLEVEL) if not defined\n"
     line += f"OPTLEVEL ?= {optlevel.replace('/', '-')}\n\n"
     f.write(line)

--- a/pymake/pymake_build_apps.py
+++ b/pymake/pymake_build_apps.py
@@ -228,9 +228,7 @@ def build_apps(
 
             # determine if the target should be built
             build_target = pmobj.set_build_target_bool(
-                target=pmobj.update_target(
-                    target, modify_target=update_target_name
-                )
+                target=pmobj.update_target(target, modify_target=update_target_name)
             )
 
             # setup download for target
@@ -252,10 +250,7 @@ def build_apps(
         end_downcomp = datetime.now()
         elapsed = end_downcomp - start_downcomp
         if pmobj.verbose:
-            print(
-                "elapsed download and compile time (hh:mm:ss.ms): "
-                + f"{elapsed}\n"
-            )
+            print("elapsed download and compile time (hh:mm:ss.ms): " + f"{elapsed}\n")
 
     end_time = datetime.now()
     elapsed = end_time - start_time

--- a/pymake/utils/_Popen_wrapper.py
+++ b/pymake/utils/_Popen_wrapper.py
@@ -91,10 +91,7 @@ def _process_Popen_communicate(proc, verbose=True):
 
     # catch non-zero return code
     if proc.returncode != 0:
-        msg = (
-            f"{' '.join(proc.args)} failed\n"
-            + f"\tstatus code {proc.returncode}\n"
-        )
+        msg = f"{' '.join(proc.args)} failed\n" + f"\tstatus code {proc.returncode}\n"
         print(msg)
 
     return stderr, stdout

--- a/pymake/utils/_compiler_language_files.py
+++ b/pymake/utils/_compiler_language_files.py
@@ -188,10 +188,7 @@ def _preprocess_file(srcfiles, meson=False):
                 break
 
         else:
-            msg = (
-                "_preprocess_file: could not "
-                + f"open {os.path.basename(srcfile)}"
-            )
+            msg = "_preprocess_file: could not " + f"open {os.path.basename(srcfile)}"
             raise FileNotFoundError(msg)
 
     return preprocess

--- a/pymake/utils/_compiler_switches.py
+++ b/pymake/utils/_compiler_switches.py
@@ -160,9 +160,7 @@ def _get_prepend(compiler, osname):
     return prepend
 
 
-def _get_optlevel(
-    target, fc, cc, debug, fflags, cflags, osname=None, verbose=False
-):
+def _get_optlevel(target, fc, cc, debug, fflags, cflags, osname=None, verbose=False):
     """Return a compiler optimization switch.
 
     Parameters
@@ -339,9 +337,7 @@ def _get_fortran_flags(
                         flags.append("pedantic")
                     if _check_gnu_switch_available("-Wcharacter-truncation"):
                         flags.append("Wcharacter-truncation")
-                    if _check_gnu_switch_available(
-                        "-Wno-unused-dummy-argument"
-                    ):
+                    if _check_gnu_switch_available("-Wno-unused-dummy-argument"):
                         flags.append("Wno-unused-dummy-argument")
                     if _check_gnu_switch_available("-Wno-intrinsic-shadow"):
                         flags.append("Wno-intrinsic-shadow")
@@ -811,9 +807,7 @@ def _set_fflags(target, fc="gfortran", argv=True, osname=None, verbose=False):
         ):
             if fc == "gfortran":
                 opt = "-fallow-argument-mismatch"
-                if _check_gnu_switch_available(
-                    opt, compiler=fc, verbose=verbose
-                ):
+                if _check_gnu_switch_available(opt, compiler=fc, verbose=verbose):
                     fflags += [
                         opt,
                     ]

--- a/pymake/utils/_dag.py
+++ b/pymake/utils/_dag.py
@@ -136,9 +136,7 @@ def _get_f_nodelist(srcfiles):
         try:
             f = open(srcfile, "rb")
         except:
-            print(
-                f"get_f_nodelist: could not open {os.path.basename(srcfile)}"
-            )
+            print(f"get_f_nodelist: could not open {os.path.basename(srcfile)}")
             sourcefile_module_dict[srcfile] = []
             continue
         lines = f.read()
@@ -262,8 +260,7 @@ def _order_c_source_files(srcfiles, networkx):
             f = open(srcfile, "rb")
         except:
             print(
-                "order_c_source_files: could not open "
-                + f"{os.path.basename(srcfile)}"
+                "order_c_source_files: could not open " + f"{os.path.basename(srcfile)}"
             )
             sourcefile_module_dict[srcfile] = []
             continue
@@ -284,10 +281,7 @@ def _order_c_source_files(srcfiles, networkx):
                 # add source file for this c(pp) file if it is the same
                 # as the include file without the extension
                 bn = os.path.basename(srcfile)
-                if (
-                    os.path.splitext(modulename)[0]
-                    == os.path.splitext(bn)[0].upper()
-                ):
+                if os.path.splitext(modulename)[0] == os.path.splitext(bn)[0].upper():
                     module_dict[modulename] = srcfile
 
                 # add include file name

--- a/pymake/utils/_file_utils.py
+++ b/pymake/utils/_file_utils.py
@@ -58,9 +58,7 @@ def _get_extrafiles_common_path(external_files):
     if external_files is None:
         common_path = None
     else:
-        common_path = os.path.commonpath(
-            _get_extra_exclude_files(external_files)
-        )
+        common_path = os.path.commonpath(_get_extra_exclude_files(external_files))
         for tag in (f"src{os.sep}", f"source{os.sep}"):
             if tag in common_path:
                 str_index = common_path.find(tag)

--- a/pymake/utils/_meson_build.py
+++ b/pymake/utils/_meson_build.py
@@ -190,9 +190,7 @@ def meson_setup(
         else:
             command_list.append("--prefix=$(pwd)")
 
-        libdir = os.path.relpath(
-            os.path.abspath(appdir), os.path.abspath(mesondir)
-        )
+        libdir = os.path.relpath(os.path.abspath(appdir), os.path.abspath(mesondir))
         command_list.append(f"--libdir={libdir}")
         command_list.append(f"--bindir={libdir}")
 

--- a/pymake/utils/_usgs_src_update.py
+++ b/pymake/utils/_usgs_src_update.py
@@ -122,9 +122,7 @@ def _update_triangle_files(srcdir, fc, cc, arch, double):
         with open(src, "r") as f:
             lines = f.readlines()
             for idx, line in enumerate(lines):
-                lines[idx] = line.replace(
-                    "unsigned long", "unsigned long long"
-                )
+                lines[idx] = line.replace("unsigned long", "unsigned long long")
         with open(src, "w") as f:
             for line in lines:
                 f.write(line)
@@ -245,13 +243,8 @@ def _update_swtv4_files(srcdir, fc, cc, arch, double):
             lines = [line.rstrip() for line in open(fpth)]
             f = open(fpth, "w")
             for line in lines:
-                if (
-                    "      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT"
-                    in line
-                ):
-                    line = (
-                        "C      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT"
-                    )
+                if "      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT" in line:
+                    line = "C      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT"
                 f.write(f"{line}\n")
             f.close()
     else:
@@ -262,20 +255,10 @@ def _update_swtv4_files(srcdir, fc, cc, arch, double):
             f = open(fpth, "w")
             for line in lines:
                 # comment out the 32 bit one and activate the 64 bit line
-                if (
-                    "C      !DEC$ ATTRIBUTES ALIAS:'resprint' :: RESPRINT"
-                    in line
-                ):
-                    line = (
-                        "       !DEC$ ATTRIBUTES ALIAS:'resprint' :: RESPRINT"
-                    )
-                if (
-                    "      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT"
-                    in line
-                ):
-                    line = (
-                        "C      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT"
-                    )
+                if "C      !DEC$ ATTRIBUTES ALIAS:'resprint' :: RESPRINT" in line:
+                    line = "       !DEC$ ATTRIBUTES ALIAS:'resprint' :: RESPRINT"
+                if "      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT" in line:
+                    line = "C      !DEC$ ATTRIBUTES ALIAS:'_resprint' :: RESPRINT"
                 f.write(f"{line}\n")
             f.close()
 
@@ -499,15 +482,11 @@ def _update_mf2000_files(srcdir, fc, cc, arch, double):
 
     # Move src files and serial src file to src directory
     tpth = os.path.join(srcdir, "mf2k")
-    files = [
-        f for f in os.listdir(tpth) if os.path.isfile(os.path.join(tpth, f))
-    ]
+    files = [f for f in os.listdir(tpth) if os.path.isfile(os.path.join(tpth, f))]
     for f in files:
         shutil.move(os.path.join(tpth, f), os.path.join(srcdir, f))
     tpth = os.path.join(srcdir, "mf2k", "serial")
-    files = [
-        f for f in os.listdir(tpth) if os.path.isfile(os.path.join(tpth, f))
-    ]
+    files = [f for f in os.listdir(tpth) if os.path.isfile(os.path.join(tpth, f))]
     for f in files:
         shutil.move(os.path.join(tpth, f), os.path.join(srcdir, f))
 

--- a/pymake/utils/download.py
+++ b/pymake/utils/download.py
@@ -390,9 +390,9 @@ def download_and_unzip(
                         # write information to the screen
                         if verbose:
                             if file_size > 0:
-                                download_percent = float(
-                                    download_size
-                                ) / float(file_size)
+                                download_percent = float(download_size) / float(
+                                    file_size
+                                )
                                 msg = (
                                     "     downloaded "
                                     + sbfmt.format(bfmt.format(download_size))
@@ -445,9 +445,7 @@ def download_and_unzip(
         raise ConnectionError(msg)
 
     # Unzip the file, and delete zip file if successful.
-    if "zip" in os.path.basename(file_name) or "exe" in os.path.basename(
-        file_name
-    ):
+    if "zip" in os.path.basename(file_name) or "exe" in os.path.basename(file_name):
         z = pymakeZipFile(file_name)
         try:
             # write a message
@@ -545,9 +543,7 @@ def _get_zipname(platform):
             else:
                 platform = "win32"
         else:
-            errmsg = (
-                f"Could not determine platform. sys.platform is {sys.platform}"
-            )
+            errmsg = f"Could not determine platform. sys.platform is {sys.platform}"
             raise Exception(errmsg)
     else:
         msg = f"unknown platform detected ({platform})"
@@ -579,10 +575,7 @@ def _get_default_url():
 
     """
 
-    return (
-        f"https://github.com/{_get_default_repo()}/"
-        + "releases/latest/download/"
-    )
+    return f"https://github.com/{_get_default_repo()}/" + "releases/latest/download/"
 
 
 def _get_default_json(tag_name=None):
@@ -611,10 +604,7 @@ def _get_default_json(tag_name=None):
             + f"releases/latest/download/{tag_name}/"
         )
     else:
-        url = (
-            f"https://github.com/{_get_default_repo()}/"
-            + "releases/latest/download/"
-        )
+        url = f"https://github.com/{_get_default_repo()}/" + "releases/latest/download/"
 
     # define asset names and paths for assets
     names = ["mac.zip", "linux.zip", "win32.zip", "win64.zip"]
@@ -714,10 +704,7 @@ def _repo_json(
                     request_url = release["url"]
                     break
             if request_url is None:
-                msg = (
-                    f"Could not find tag_name ('{tag_name}') "
-                    + "in release catalog"
-                )
+                msg = f"Could not find tag_name ('{tag_name}') " + "in release catalog"
                 if error_return:
                     print(msg)
                     return None
@@ -764,9 +751,7 @@ def _repo_json(
     return json_obj
 
 
-def get_repo_assets(
-    github_repo=None, version=None, error_return=False, verify=True
-):
+def get_repo_assets(github_repo=None, version=None, error_return=False, verify=True):
     """Return a dictionary containing the file name and the link to the asset
     contained in a github repository.
 

--- a/pymake/utils/usgsprograms.py
+++ b/pymake/utils/usgsprograms.py
@@ -416,9 +416,7 @@ class usgs_program_data:
                             tzinfo=datetime.timezone.utc
                         )
                         datetime_str = datetime_obj_utc.strftime("%m/%d/%Y")
-                        prog_data[target]["url_download_asset_date"] = (
-                            datetime_str
-                        )
+                        prog_data[target]["url_download_asset_date"] = datetime_str
                         break
 
         if partial_json:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,15 +91,7 @@ include = ["pymake", "pymake.*"]
 fallback_version = "999"
 
 [tool.ruff]
-line-length = 79
-target-version = "py38"
-include = [
-    "pyproject.toml",
-    "pymake/**/*.py",
-    "autotest/**/*.py",
-    "docs/**/*.py",
-    "scripts/**/*.py",
-]
+line-length = 88
 
 [tool.ruff.lint]
 select = ["F", "E", "I001"]

--- a/scripts/update_version.py
+++ b/scripts/update_version.py
@@ -149,8 +149,7 @@ if __name__ == "__main__":
         "--get",
         required=False,
         action="store_true",
-        help="Just get the current version number, "
-        + "no updates (defaults false)",
+        help="Just get the current version number, " + "no updates (defaults false)",
     )
     args = parser.parse_args()
 
@@ -159,7 +158,5 @@ if __name__ == "__main__":
     else:
         update_version(
             timestamp=datetime.now(),
-            version=(
-                Version(args.version) if args.version else _current_version
-            ),
+            version=(Version(args.version) if args.version else _current_version),
         )


### PR DESCRIPTION
This PR reformats the code with a maximum line length of 88 characters to better represent the code.

See https://github.com/modflowpy/flopy/pull/2362 for a related PR with rational and discussion.

This PR also changes some of Ruff's configuration:

- Remove `target-version`, since it is automatically evaluated from `pyproject.toml`
- Remove `include` so that Ruff will work globally in this repo
