### PR TITLE
ci: pin ubuntu-22.04 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           # - {os: macos-latest, FC: gcc, FC_V: 13, shell: bash}
           # - {os: windows-latest, FC: gcc, FC_V: 13, shell: pwsh}
           # test latest python and intel-classic
-          - {os: ubuntu-latest, FC: intel-classic, FC_V: 2021.7, shell: bash}
+          - {os: ubuntu-22.04, FC: intel-classic, FC_V: 2021.7, shell: bash}
           # - {os: macos-13, FC: intel-classic, FC_V: 2021.7, shell: bash}
           # - {os: windows-2019, FC: intel-classic, FC_V: 2021.7, shell: pwsh}
           # test latest python and previous gcc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,16 @@ jobs:
       matrix:
         include:
           # test latest gcc and python
-          - {os: ubuntu-latest, FC: gcc, FC_V: 13, shell: bash}
-          - {os: macos-latest, FC: gcc, FC_V: 13, shell: bash}
-          - {os: windows-latest, FC: gcc, FC_V: 13, shell: pwsh}
+          # - {os: ubuntu-latest, FC: gcc, FC_V: 13, shell: bash}
+          # - {os: macos-latest, FC: gcc, FC_V: 13, shell: bash}
+          # - {os: windows-latest, FC: gcc, FC_V: 13, shell: pwsh}
           # test latest python and intel-classic
           - {os: ubuntu-latest, FC: intel-classic, FC_V: 2021.7, shell: bash}
-          - {os: macos-13, FC: intel-classic, FC_V: 2021.7, shell: bash}
-          - {os: windows-2019, FC: intel-classic, FC_V: 2021.7, shell: pwsh}
+          # - {os: macos-13, FC: intel-classic, FC_V: 2021.7, shell: bash}
+          # - {os: windows-2019, FC: intel-classic, FC_V: 2021.7, shell: pwsh}
           # test latest python and previous gcc
-          - {os: ubuntu-latest, FC: gcc, FC_V: 12, shell: bash}
-          - {os: ubuntu-latest, FC: gcc, FC_V: 11, shell: bash}
+          # - {os: ubuntu-latest, FC: gcc, FC_V: 12, shell: bash}
+          # - {os: ubuntu-latest, FC: gcc, FC_V: 11, shell: bash}
     defaults:
       run:
         shell: ${{ matrix.shell }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,16 +27,16 @@ jobs:
       matrix:
         include:
           # test latest gcc and python
-          # - {os: ubuntu-latest, FC: gcc, FC_V: 13, shell: bash}
-          # - {os: macos-latest, FC: gcc, FC_V: 13, shell: bash}
-          # - {os: windows-latest, FC: gcc, FC_V: 13, shell: pwsh}
+          - {os: ubuntu-latest, FC: gcc, FC_V: 13, shell: bash}
+          - {os: macos-latest, FC: gcc, FC_V: 13, shell: bash}
+          - {os: windows-latest, FC: gcc, FC_V: 13, shell: pwsh}
           # test latest python and intel-classic
           - {os: ubuntu-22.04, FC: intel-classic, FC_V: 2021.7, shell: bash}
-          # - {os: macos-13, FC: intel-classic, FC_V: 2021.7, shell: bash}
-          # - {os: windows-2019, FC: intel-classic, FC_V: 2021.7, shell: pwsh}
+          - {os: macos-13, FC: intel-classic, FC_V: 2021.7, shell: bash}
+          - {os: windows-2019, FC: intel-classic, FC_V: 2021.7, shell: pwsh}
           # test latest python and previous gcc
-          # - {os: ubuntu-latest, FC: gcc, FC_V: 12, shell: bash}
-          # - {os: ubuntu-latest, FC: gcc, FC_V: 11, shell: bash}
+          - {os: ubuntu-latest, FC: gcc, FC_V: 12, shell: bash}
+          - {os: ubuntu-latest, FC: gcc, FC_V: 11, shell: bash}
     defaults:
       run:
         shell: ${{ matrix.shell }}

--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -36,6 +36,8 @@ def pm(module_tmpdir, target) -> pymake.Pymake:
     pm.fc = None
     pm.inplace = True
     pm.makeclean = True
+    if system() == "Linux":
+        pm.cflags = "-D_Float128=__float12"
     yield pm
     pm.finalize()
 

--- a/autotest/test_gridgen.py
+++ b/autotest/test_gridgen.py
@@ -36,8 +36,6 @@ def pm(module_tmpdir, target) -> pymake.Pymake:
     pm.fc = None
     pm.inplace = True
     pm.makeclean = True
-    if system() == "Linux":
-        pm.cflags = "-D_Float128=__float12"
     yield pm
     pm.finalize()
 


### PR DESCRIPTION
Workaround oneAPI incompatibility with `ubuntu-24.04`