### PR TITLE
chore: fix typos and add codespell configuration

### DIFF
--- a/.github/workflows/pymake-linting-install.yml
+++ b/.github/workflows/pymake-linting-install.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Check format
         run: pixi run check-format
 
+      - name: Check spelling
+        run: pixi run check-spelling
+
   pymake_setup:
     name: standard installation
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ options:
                         List of extra source files to exclude from the compilation. excludefiles can be either a list of files or the name of a text file that contains a list of files. (default is None)
   -so, --sharedobject   Create shared object or dll on Windows. (default is False)
   -ad APPDIR, --appdir APPDIR
-                        Target path that overides path defined target path (default is None)
+                        Target path that overrides path defined target path (default is None)
   -v, --verbose         Verbose output to terminal. (default is False)
   --keep                Keep existing executable. (default is False)
   --zip ZIP             Zip built executable. (default is None)

--- a/docs/build_apps.md
+++ b/docs/build_apps.md
@@ -31,7 +31,7 @@ options:
                         Additional C/C++ compiler flags. C/C++ compiler flags should be enclosed in quotes and start with a blank space or separated from the name (-cf or --cflags) with a equal sign
                         (-cf='-O3'). (default is None)
   -ad APPDIR, --appdir APPDIR
-                        Target path that overides path defined target path (default is None)
+                        Target path that overrides path defined target path (default is None)
   -v, --verbose         Verbose output to terminal. (default is False)
   --keep                Keep existing executable. (default is False)
   --zip ZIP             Zip built executable. (default is None)
@@ -60,7 +60,7 @@ connection), unzips the distribution file, sets the pymake settings required to 
 source files to build the program. MT3DMS will be downloaded from the University of Alabama and Triangle will be
 downloaded from [netlib.org](http://www.netlib.org/voronoi/triangle.zip). Optional command line arguments can be used to
 customize the build (`-fc`, `-cc`, `--fflags`, etc.). For example, MODFLOW 6 could be built using intel compilers and
-an `O3` optimation level by specifying:
+an `O3` optimization level by specifying:
 
 ```console
 make-program mf6 -fc=ifort --fflags='-O3'

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -22,7 +22,7 @@ mfpymake -h
 ```
 
 The help message identifies required positional arguments and optional
-arguments that can be provided to overide default values.
+arguments that can be provided to override default values.
 
 ```
 usage: mfpymake [-h] [-fc {ifort,mpiifort,gfortran,none}]
@@ -97,7 +97,7 @@ optional arguments:
   -so, --sharedobject   Create shared object or dll on Windows. (default is
                         False)
   -ad APPDIR, --appdir APPDIR
-                        Target path that overides path defined target path
+                        Target path that overrides path defined target path
                         (default is None)
   -v, --verbose         Verbose output to terminal. (default is False)
   --keep                Keep existing executable. (default is False)

--- a/pixi.toml
+++ b/pixi.toml
@@ -36,7 +36,9 @@ postinstall = "pip install --no-build-isolation --no-deps --disable-pip-version-
 # format
 check-lint = "ruff check ."
 check-format = "ruff format . --check"
+check-spelling = "codespell"
 fix-style = "ruff check . --fix; ruff format ."
+
 
 # build
 test = "meson test --verbose --no-rebuild -C"

--- a/pymake/cmds/createjson.py
+++ b/pymake/cmds/createjson.py
@@ -57,7 +57,7 @@ Examples:
         },
         "appdir": {
             "tag": ("-ad", "--appdir"),
-            "help": "code.json path that overides FPTH defined path. Default is None.",
+            "help": "code.json path that overrides FPTH defined path. Default is None.",
             "default": None,
             "choices": None,
             "action": None,

--- a/pymake/pymake_parser.py
+++ b/pymake/pymake_parser.py
@@ -211,7 +211,7 @@ def _get_standard_arg_dict():
         },
         "appdir": {
             "tag": ("-ad", "--appdir"),
-            "help": """Target path that overides path defined target
+            "help": """Target path that overrides path defined target
                          path (default is None)""",
             "default": None,
             "choices": None,

--- a/pymake/utils/_Popen_wrapper.py
+++ b/pymake/utils/_Popen_wrapper.py
@@ -17,7 +17,7 @@ def _process_Popen_initialize(cmdlist, intelwin=False, cwd=None):
         boolean indicating is Intel compilers are being used on Windows and
         if stderr should be sent to the terminal
     cwd : str
-        path to execute Popen in (defaulr is None)
+        path to execute Popen in (default is None)
 
     Returns
     -------

--- a/pymake/utils/_compiler_switches.py
+++ b/pymake/utils/_compiler_switches.py
@@ -44,7 +44,7 @@ def linker_update_environment(cc="gcc", fc="gfortran", verbose=False):
 
 def _check_gnu_switch_available(switch, compiler="gfortran", verbose=False):
     """Determine if a specified GNU compiler switch exists. Not all switches
-    will be detected, for example '-O2'  adn '-fbounds-check=on'.
+    will be detected, for example '-O2'  and '-fbounds-check=on'.
 
     Parameters
     ----------
@@ -174,7 +174,7 @@ def _get_optlevel(target, fc, cc, debug, fflags, cflags, osname=None):
     cc : str
         c or cpp compiler
     debug : bool
-        flag indicating is a debug executible will be built
+        flag indicating is a debug executable will be built
     fflags : list
         user provided list of fortran compiler flags
     cflags : list
@@ -488,7 +488,7 @@ def _get_c_flags(
                 pass
         elif cc in ["clang", "clang++"]:
             if sharedobject:
-                msg = "shared library not implement fo clang"
+                msg = "shared library not implement for clang"
                 raise NotImplementedError(msg)
             if debug:
                 flags += ["g"]
@@ -1072,7 +1072,7 @@ def _darwin_syslibs(cc, fc, verbose=False):
     Returns
     -------
     linker_str : str
-        additiona; linker flags for darwin systems. Default is None
+        additional; linker flags for darwin systems. Default is None
     """
     linker_str = None
     if _get_osname() == "darwin":

--- a/pymake/utils/usgsprograms.py
+++ b/pymake/utils/usgsprograms.py
@@ -5,7 +5,7 @@ application database. Available functionality includes:
 2. Get data for a specific target
 3. Get a dictionary with the data for all targets
 4. Get the current version of a target
-5. Get a list indicating if single and double precsion versions of the
+5. Get a list indicating if single and double precision versions of the
    target application should be built
 6. Functions to load, update, and export a USGS-style "code.json" json file
    containing information in the USGS application database
@@ -314,7 +314,7 @@ class usgs_program_data:
         fpth : str
             Path for the json file to be created. Default is "code.json"
         appdir : str
-            path for code.json. Overides code.json path defined in fpth.
+            path for code.json. Overrides code.json path defined in fpth.
             Default is None.
         prog_data : dict
             User-specified program database. If prog_data is None, it will

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,3 +100,9 @@ ignore = [
     "RUF022", # Apply an isort-style sorting to `__all__`
     "UP015", # redundant open modes
 ]
+
+[tool.codespell]
+ignore-words-list = [
+    "Fo",
+    "nam",
+]


### PR DESCRIPTION
Fix a few typos, add `check-spelling` pixi task that runs in CI.