### PR TITLE
ci: add token to env for requests tests

### DIFF
--- a/.github/workflows/pymake-requests.yml
+++ b/.github/workflows/pymake-requests.yml
@@ -42,6 +42,8 @@ jobs:
           pixi run postinstall
 
       - name: Run pytest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pixi run autotest-request
 


### PR DESCRIPTION
Should avoid rate limiting like [here](https://github.com/modflowpy/pymake/actions/runs/14335676128/job/40182004918?pr=232)?