### PR TITLE
fix: remove ambiguous abbreviation for make-program --exclude

### DIFF
--- a/docs/build_apps.md
+++ b/docs/build_apps.md
@@ -7,7 +7,7 @@ and options can be determined by executing:
 ```console
 $ make-program --help
 
-usage: make-program [-h] [-ex EXCLUDE] [-fc {ifort,mpiifort,gfortran,none}] [-cc {gcc,clang,clang++,icc,icl,mpiicc,g++,cl,none}] [-dbl] [-dr] [-ff FFLAGS] [-cf CFLAGS] [-ad APPDIR] [-v] [--keep] [--zip ZIP]
+usage: make-program [-h] [--exclude EXCLUDE] [-fc {ifort,mpiifort,gfortran,none}] [-cc {gcc,clang,clang++,icc,icl,mpiicc,g++,cl,none}] [-dbl] [-dr] [-ff FFLAGS] [-cf CFLAGS] [-ad APPDIR] [-v] [--keep] [--zip ZIP]
                     [--meson]
                     targets
 
@@ -19,8 +19,7 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
-  -ex EXCLUDE, --exclude EXCLUDE
-                        exclude specific target(s) from build
+  --exclude EXCLUDE     exclude specific target(s) from build
   -fc {ifort,mpiifort,gfortran,none}
                         Fortran compiler to use. (default is gfortran)
   -cc {gcc,clang,clang++,icc,icl,mpiicc,g++,cl,none}

--- a/pymake/cmds/build.py
+++ b/pymake/cmds/build.py
@@ -100,10 +100,7 @@ Examples:
             "action": None,
         },
         "exclude": {
-            "tag": (
-                "-ex",
-                "--exclude",
-            ),
+            "tag": ("--exclude",),
             "help": "exclude specific target(s) from build",
             "default": None,
             "choices": None,


### PR DESCRIPTION
When I run `make-program` with `-ex ...` I get

```
usage: make-program [-h] [-fc {ifort,mpiifort,gfortran,none}] [-cc {gcc,clang,clang++,icc,icl,mpiicc,g++,cl,none}] [-ar {ia32,ia32_intel64,intel64}] [-mc] [-dbl] [-dbg]
                    [-e] [-dr] [-sd] [-ff FFLAGS] [-cf CFLAGS] [-sl {-lc,-lm}] [-mf] [-md] [-cs COMMONSRC] [-ef EXTRAFILES] [-exf EXCLUDEFILES] [-so] [-ad APPDIR] [-v]
                    [--keep] [--zip ZIP] [--inplace] [--networkx] [--meson] [--mesondir]
make-program: error: ambiguous option: -ex could match -e, -exf
```

I tried passing `allow_abbrev=False` to the argparse initializer but it didn't solve it.