### PR TITLE
fix: use unix path separators in makefiles

### DIFF
--- a/pymake/pymake_base.py
+++ b/pymake/pymake_base.py
@@ -1367,7 +1367,7 @@ def _create_makefile(
     f.write(line)
     vpaths = []
     for idx, source_dir in enumerate(dirs):
-        rel_source_dir = os.path.relpath(source_dir, make_dir)
+        rel_source_dir = os.path.relpath(source_dir, make_dir).replace("\\", "/")
         vpaths.append(f"SOURCEDIR{idx + 1}")
         line = f"{vpaths[idx]}={rel_source_dir}\n"
         f.write(line)


### PR DESCRIPTION
There is a conversion to Unix path separators on L1349 but then calling `relpath()` restores Windows separators again. Add another conversion so generated makefiles consistently use Unix path separators, even when generated on Windows.